### PR TITLE
DCON-3458: Added the option to edit the match request payload

### DIFF
--- a/src/admin/personMatch.tsx
+++ b/src/admin/personMatch.tsx
@@ -198,7 +198,12 @@ const PersonMatchPage: React.FC = () => {
                                         <Box>
                                             <textarea
                                                 value={editedPayload}
-                                                onChange={(e) => setEditedPayload(e.target.value)}
+                                                onChange={(e) => {
+                                                    setEditedPayload(e.target.value);
+                                                    if (editError) {
+                                                        setEditError('');
+                                                    }
+                                                }}
                                                 style={{
                                                     width: '100%',
                                                     minHeight: '300px',

--- a/src/admin/personMatch.tsx
+++ b/src/admin/personMatch.tsx
@@ -12,7 +12,10 @@ import {
     Paper,
     FormControlLabel,
     Checkbox,
+    IconButton,
+    Alert,
 } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
 import AdminApi from '../api/adminApi';
 import EnvironmentContext from '../context/EnvironmentContext';
 import PreJson from '../components/PreJson';
@@ -32,12 +35,16 @@ const PersonMatchPage: React.FC = () => {
     const [matchRequest, setMatchRequest] = useState<any>(null);
     const [matchResponse, setMatchResponse] = useState<any>(null);
     const [isLoading, setIsLoading] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
+    const [editedPayload, setEditedPayload] = useState<string>('');
+    const [editError, setEditError] = useState<string>('');
 
     const handleSubmit = async (event: React.FormEvent) => {
         event.preventDefault();
         setIsLoading(true);
         setMatchRequest(null);
         setMatchResponse(null);
+        setIsEditing(false);
         const data = await adminApi.runPersonMatch({
             sourceId,
             sourceType,
@@ -52,6 +59,34 @@ const PersonMatchPage: React.FC = () => {
         } else {
             setMatchResponse(json);
         }
+        setIsLoading(false);
+    };
+
+    const handleEditClick = () => {
+        setEditedPayload(JSON.stringify(matchRequest, null, 2));
+        setEditError('');
+        setIsEditing(true);
+    };
+
+    const handleCancelEdit = () => {
+        setIsEditing(false);
+        setEditError('');
+    };
+
+    const handleSendEdited = async () => {
+        let parsed;
+        try {
+            parsed = JSON.parse(editedPayload);
+        } catch {
+            setEditError('Invalid JSON');
+            return;
+        }
+        setEditError('');
+        setIsLoading(true);
+        const data = await adminApi.runMatchWithPayload(parsed);
+        setMatchRequest(parsed);
+        setMatchResponse(data.json);
+        setIsEditing(false);
         setIsLoading(false);
     };
 
@@ -146,8 +181,43 @@ const PersonMatchPage: React.FC = () => {
                         matchRequest ? (
                             <Box sx={{ display: 'flex', gap: 2, mt: 2, overflow: 'hidden' }}>
                                 <Paper variant="outlined" sx={{ flex: 1, minWidth: 0, overflow: 'auto', p: 2 }}>
-                                    <Typography variant="h6" sx={{ mb: 1 }}>Match Request</Typography>
-                                    <PreJson data={matchRequest} collapsed={2} />
+                                    <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                                        <Typography variant="h6" sx={{ flexGrow: 1 }}>Match Request</Typography>
+                                        {!isEditing && (
+                                            <IconButton size="small" onClick={handleEditClick} title="Edit payload">
+                                                <EditIcon fontSize="small" />
+                                            </IconButton>
+                                        )}
+                                    </Box>
+                                    {isEditing ? (
+                                        <Box>
+                                            <textarea
+                                                value={editedPayload}
+                                                onChange={(e) => setEditedPayload(e.target.value)}
+                                                style={{
+                                                    width: '100%',
+                                                    minHeight: '300px',
+                                                    fontFamily: 'monospace',
+                                                    fontSize: '13px',
+                                                    padding: '8px',
+                                                    border: '1px solid #ccc',
+                                                    borderRadius: '4px',
+                                                    resize: 'vertical',
+                                                }}
+                                            />
+                                            {editError && <Alert severity="error" sx={{ mt: 1 }}>{editError}</Alert>}
+                                            <Box sx={{ mt: 1, display: 'flex', gap: 1 }}>
+                                                <Button variant="contained" size="small" onClick={handleSendEdited}>
+                                                    Send
+                                                </Button>
+                                                <Button variant="outlined" size="small" onClick={handleCancelEdit}>
+                                                    Cancel
+                                                </Button>
+                                            </Box>
+                                        </Box>
+                                    ) : (
+                                        <PreJson data={matchRequest} collapsed={2} />
+                                    )}
                                 </Paper>
                                 <Paper variant="outlined" sx={{ flex: 1, minWidth: 0, overflow: 'auto', p: 2 }}>
                                     <Typography variant="h6" sx={{ mb: 1 }}>Match Response</Typography>

--- a/src/admin/personMatch.tsx
+++ b/src/admin/personMatch.tsx
@@ -184,7 +184,12 @@ const PersonMatchPage: React.FC = () => {
                                     <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                                         <Typography variant="h6" sx={{ flexGrow: 1 }}>Match Request</Typography>
                                         {!isEditing && (
-                                            <IconButton size="small" onClick={handleEditClick} title="Edit payload">
+                                            <IconButton
+                                                size="small"
+                                                onClick={handleEditClick}
+                                                title="Edit payload"
+                                                aria-label="Edit payload"
+                                            >
                                                 <EditIcon fontSize="small" />
                                             </IconButton>
                                         )}

--- a/src/admin/personMatch.tsx
+++ b/src/admin/personMatch.tsx
@@ -197,6 +197,7 @@ const PersonMatchPage: React.FC = () => {
                                     {isEditing ? (
                                         <Box>
                                             <textarea
+                                                aria-label="Edit match request payload"
                                                 value={editedPayload}
                                                 onChange={(e) => {
                                                     setEditedPayload(e.target.value);

--- a/src/admin/personOneToNMatch.tsx
+++ b/src/admin/personOneToNMatch.tsx
@@ -12,7 +12,10 @@ import {
     Paper,
     FormControlLabel,
     Checkbox,
+    IconButton,
+    Alert,
 } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
 import AdminApi from '../api/adminApi';
 import EnvironmentContext from '../context/EnvironmentContext';
 import PreJson from '../components/PreJson';
@@ -31,6 +34,9 @@ const PersonOneToNMatchPage: React.FC = () => {
     const [matchRequest, setMatchRequest] = useState<any>(null);
     const [matchResponse, setMatchResponse] = useState<any>(null);
     const [isLoading, setIsLoading] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
+    const [editedPayload, setEditedPayload] = useState<string>('');
+    const [editError, setEditError] = useState<string>('');
 
     const handleMatchResourceTypeChange = (event: { target: { value: string } }) => {
         setMatchResourceType(event.target.value.split(' ').join(''));
@@ -41,6 +47,7 @@ const PersonOneToNMatchPage: React.FC = () => {
         setIsLoading(true);
         setMatchRequest(null);
         setMatchResponse(null);
+        setIsEditing(false);
         const data = await adminApi.runPersonOneToNMatch({
             id,
             resourceType,
@@ -54,6 +61,34 @@ const PersonOneToNMatchPage: React.FC = () => {
         } else {
             setMatchResponse(json);
         }
+        setIsLoading(false);
+    };
+
+    const handleEditClick = () => {
+        setEditedPayload(JSON.stringify(matchRequest, null, 2));
+        setEditError('');
+        setIsEditing(true);
+    };
+
+    const handleCancelEdit = () => {
+        setIsEditing(false);
+        setEditError('');
+    };
+
+    const handleSendEdited = async () => {
+        let parsed;
+        try {
+            parsed = JSON.parse(editedPayload);
+        } catch {
+            setEditError('Invalid JSON');
+            return;
+        }
+        setEditError('');
+        setIsLoading(true);
+        const data = await adminApi.runMatchWithPayload(parsed);
+        setMatchRequest(parsed);
+        setMatchResponse(data.json);
+        setIsEditing(false);
         setIsLoading(false);
     };
 
@@ -132,8 +167,43 @@ const PersonOneToNMatchPage: React.FC = () => {
                         matchRequest ? (
                             <Box sx={{ display: 'flex', gap: 2, mt: 2, overflow: 'hidden' }}>
                                 <Paper variant="outlined" sx={{ flex: 1, minWidth: 0, overflow: 'auto', p: 2 }}>
-                                    <Typography variant="h6" sx={{ mb: 1 }}>Match Request</Typography>
-                                    <PreJson data={matchRequest} collapsed={2} />
+                                    <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                                        <Typography variant="h6" sx={{ flexGrow: 1 }}>Match Request</Typography>
+                                        {!isEditing && (
+                                            <IconButton size="small" onClick={handleEditClick} title="Edit payload">
+                                                <EditIcon fontSize="small" />
+                                            </IconButton>
+                                        )}
+                                    </Box>
+                                    {isEditing ? (
+                                        <Box>
+                                            <textarea
+                                                value={editedPayload}
+                                                onChange={(e) => setEditedPayload(e.target.value)}
+                                                style={{
+                                                    width: '100%',
+                                                    minHeight: '300px',
+                                                    fontFamily: 'monospace',
+                                                    fontSize: '13px',
+                                                    padding: '8px',
+                                                    border: '1px solid #ccc',
+                                                    borderRadius: '4px',
+                                                    resize: 'vertical',
+                                                }}
+                                            />
+                                            {editError && <Alert severity="error" sx={{ mt: 1 }}>{editError}</Alert>}
+                                            <Box sx={{ mt: 1, display: 'flex', gap: 1 }}>
+                                                <Button variant="contained" size="small" onClick={handleSendEdited}>
+                                                    Send
+                                                </Button>
+                                                <Button variant="outlined" size="small" onClick={handleCancelEdit}>
+                                                    Cancel
+                                                </Button>
+                                            </Box>
+                                        </Box>
+                                    ) : (
+                                        <PreJson data={matchRequest} collapsed={2} />
+                                    )}
                                 </Paper>
                                 <Paper variant="outlined" sx={{ flex: 1, minWidth: 0, overflow: 'auto', p: 2 }}>
                                     <Typography variant="h6" sx={{ mb: 1 }}>Match Response</Typography>

--- a/src/admin/personOneToNMatch.tsx
+++ b/src/admin/personOneToNMatch.tsx
@@ -170,7 +170,7 @@ const PersonOneToNMatchPage: React.FC = () => {
                                     <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                                         <Typography variant="h6" sx={{ flexGrow: 1 }}>Match Request</Typography>
                                         {!isEditing && (
-                                            <IconButton size="small" onClick={handleEditClick} title="Edit payload">
+                                            <IconButton size="small" onClick={handleEditClick} aria-label="Edit payload">
                                                 <EditIcon fontSize="small" />
                                             </IconButton>
                                         )}
@@ -178,8 +178,9 @@ const PersonOneToNMatchPage: React.FC = () => {
                                     {isEditing ? (
                                         <Box>
                                             <textarea
+                                                aria-label="Edit match request payload"
                                                 value={editedPayload}
-                                                onChange={(e) => setEditedPayload(e.target.value)}
+                                                onChange={(e) => { setEditedPayload(e.target.value); setEditError(''); }}
                                                 style={{
                                                     width: '100%',
                                                     minHeight: '300px',

--- a/src/admin/personOneToNMatch.tsx
+++ b/src/admin/personOneToNMatch.tsx
@@ -64,8 +64,15 @@ const PersonOneToNMatchPage: React.FC = () => {
         setIsLoading(false);
     };
 
+    const defaultPayloadTemplate = {
+        resourceType: 'Parameters',
+        parameter: [
+            { name: 'resource', resource: { resourceType: 'Patient' } }
+        ]
+    };
+
     const handleEditClick = () => {
-        setEditedPayload(JSON.stringify(matchRequest, null, 2));
+        setEditedPayload(JSON.stringify(matchRequest || defaultPayloadTemplate, null, 2));
         setEditError('');
         setIsEditing(true);
     };
@@ -159,12 +166,22 @@ const PersonOneToNMatchPage: React.FC = () => {
                             label="Include Match Request"
                         />
                         <br />
-                        <Button type="submit" variant="contained" sx={{ mt: 1, mb: 2 }}>
-                            Run 1:N Person Matching
-                        </Button>
+                        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                            <Button type="submit" variant="contained" sx={{ mt: 1, mb: 2 }}>
+                                Run 1:N Person Matching
+                            </Button>
+                            <Button
+                                variant="outlined"
+                                sx={{ mt: 1, mb: 2 }}
+                                onClick={handleEditClick}
+                                startIcon={<EditIcon />}
+                            >
+                                Match using Demographics
+                            </Button>
+                        </Box>
                     </Box>
-                    {(matchRequest || matchResponse) && (
-                        matchRequest ? (
+                    {(matchRequest || matchResponse || isEditing) && (
+                        (matchRequest || isEditing) ? (
                             <Box sx={{ display: 'flex', gap: 2, mt: 2, overflow: 'hidden' }}>
                                 <Paper variant="outlined" sx={{ flex: 1, minWidth: 0, overflow: 'auto', p: 2 }}>
                                     <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>

--- a/src/api/adminApi.ts
+++ b/src/api/adminApi.ts
@@ -71,6 +71,11 @@ class AdminApi extends BaseApi {
         return await this.request({ urlString, params, method: 'GET' });
     }
 
+    async runMatchWithPayload(parameters: object): Promise<any> {
+        const urlString = '/admin/runMatchWithPayload';
+        return await this.request({ urlString, method: 'POST', data: parameters });
+    }
+
     async getEverythingForPatient(patientId: string): Promise<any> {
         const urlString = '/4_0_0/Patient/$everything';
         const params = {


### PR DESCRIPTION
This pull request adds an editable JSON payload feature to the admin match debug tools in both `PersonMatch` and `PersonOneToNMatch` pages. Users can now view the match request payload, edit it directly in a textarea, and re-submit the modified payload for matching. The feature includes error handling for invalid JSON and UI improvements to support the editing workflow.

**New editable match request payload feature:**

* Added an edit button to the match request panel in both `personMatch.tsx` and `personOneToNMatch.tsx`, allowing users to open a textarea to modify the JSON payload. [[1]](diffhunk://#diff-525eff1e0f6fff056ffdd946bb233daacac39b975ff96bc0a69cfab701a4fbfcL149-R220) [[2]](diffhunk://#diff-23108fd591070b31a70eb156b6d86583040d49cadc44b3b55784a6c19c34061cL135-R206)
* Implemented local state management for editing (`isEditing`, `editedPayload`, `editError`) and logic for handling edit, cancel, and send actions. [[1]](diffhunk://#diff-525eff1e0f6fff056ffdd946bb233daacac39b975ff96bc0a69cfab701a4fbfcR38-R47) [[2]](diffhunk://#diff-525eff1e0f6fff056ffdd946bb233daacac39b975ff96bc0a69cfab701a4fbfcR65-R92) [[3]](diffhunk://#diff-23108fd591070b31a70eb156b6d86583040d49cadc44b3b55784a6c19c34061cR37-R39) [[4]](diffhunk://#diff-23108fd591070b31a70eb156b6d86583040d49cadc44b3b55784a6c19c34061cR50) [[5]](diffhunk://#diff-23108fd591070b31a70eb156b6d86583040d49cadc44b3b55784a6c19c34061cR67-R94)
* Added error handling for invalid JSON input when editing the payload, displaying an error alert if parsing fails. [[1]](diffhunk://#diff-525eff1e0f6fff056ffdd946bb233daacac39b975ff96bc0a69cfab701a4fbfcL149-R220) [[2]](diffhunk://#diff-23108fd591070b31a70eb156b6d86583040d49cadc44b3b55784a6c19c34061cL135-R206)

**API support:**

* Added a new `runMatchWithPayload` method to `AdminApi` to support submitting arbitrary edited payloads for matching.

<img width="1470" height="820" alt="image" src="https://github.com/user-attachments/assets/1627efcf-ec98-4009-81ef-23bac6eae970" />

<img width="1470" height="826" alt="image" src="https://github.com/user-attachments/assets/28907f11-d8fa-4283-aef9-82fd4f9bbf68" />
