### PR TITLE
PHR-0000 Add meta.source to Composition Summary view

### DIFF
--- a/src/components/CompositionSummary.tsx
+++ b/src/components/CompositionSummary.tsx
@@ -329,6 +329,24 @@ const CompositionSummary = ({ resource, rawJsonHref }: TCompositionSummaryProps)
                                     <TableCell>{resource.identifier?.value || '—'}</TableCell>
                                 </TableRow>
                                 <TableRow>
+                                    <TableCell sx={{ fontWeight: 600 }}>Source</TableCell>
+                                    <TableCell>
+                                        {resource.meta?.source ? (
+                                            <Link
+                                                href={String(resource.meta.source)}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                                            >
+                                                {String(resource.meta.source)}
+                                                <OpenInNewIcon fontSize="inherit" />
+                                            </Link>
+                                        ) : (
+                                            '—'
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
                                     <TableCell sx={{ fontWeight: 600 }}>Subject</TableCell>
                                     <TableCell>
                                         <ReferenceLink reference={resource.subject} />


### PR DESCRIPTION
## Summary
Adds the FHIR Composition's `meta.source` as a dedicated **Source** row in the Composition Summary view (`/composition-summary/...`), between **Identifier** and **Subject**. It renders as an external link, consistent with the existing Subject/Author reference links. When `meta.source` is absent, the row shows `—` (matching the Subject/Date/Author fallback).

<img width="996" height="741" alt="Screenshot 2026-07-14 at 4 21 06 PM" src="https://github.com/user-attachments/assets/8f992435-b355-4bd1-b154-ec006b690d52" />


## Changes
- `src/components/CompositionSummary.tsx` — new `Source` `TableRow` in the metadata table.

## Testing
- Verified locally against the full stack (fhir-server + Keycloak + UI): loaded a Composition fixture with `meta.source` and confirmed the Source row renders as a clickable link.
- `yarn tsc --noEmit` passes; `eslint` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)