### PR TITLE
PHR-3348 Add Sign In With b.well App login option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ __pycache__/
 
 # superpowers subagent-driven-development scratch workspace
 .superpowers/
+
+# Playwright MCP manual verification artifacts
+.playwright-mcp/

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ out
 __pycache__/
 *.py[cod]
 .DS_Store
+
+# superpowers subagent-driven-development scratch workspace
+.superpowers/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,17 @@ services:
       # REACT_APP_AUTH_OKTA_TOKEN_TO_SEND_TO_FHIR_SERVER: 'jwt'
       # REACT_APP_AUTH_OKTA_TOKEN_FOR_USER_DETAILS: 'id_token'
       # REACT_APP_AUTH_OKTA_REMOVE_SCOPE_PREFIX: ''
+      # To configure b.well App sign-in, uncomment the following lines and set the
+      # appropriate values, and add 'bwellapp' to REACT_APP_AUTH_PROVIDERS
+      #
+      # REACT_APP_AUTH_BWELLAPP_BASE_URL: 'https://api.dev.icanbwell.com'
+      # REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS: 'Default=<client-key>'
+      # REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME: 'cognito:username'
+      # REACT_APP_AUTH_BWELLAPP_CUSTOM_GROUP: 'cognito:groups'
+      # REACT_APP_AUTH_BWELLAPP_CUSTOM_SCOPE: 'custom:scope'
+      # REACT_APP_AUTH_BWELLAPP_CLIENT_ID: 'bwellapp'
+      # REACT_APP_AUTH_BWELLAPP_TOKEN_FOR_USER_DETAILS: 'jwt'
+      # REACT_APP_AUTH_BWELLAPP_TOKEN_TO_SEND_TO_FHIR_SERVER: 'jwt'
     ports:
       - '5051:5051'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       REACT_APP_FHIR_SERVER_URL: 'http://localhost:3000'
       REACT_APP_AWS_REGION: 'us-east-1'
       # list of AuthProviders
-      REACT_APP_AUTH_PROVIDERS: 'cognito'
+      REACT_APP_AUTH_PROVIDERS: 'cognito,bwellapp'
       # Each AuthProvider has its own set of environment variables
       REACT_APP_AUTH_COGNITO_CUSTOM_USERNAME: 'cognito:username'
       REACT_APP_AUTH_COGNITO_CUSTOM_GROUP: 'cognito:groups'
@@ -29,17 +29,16 @@ services:
       # REACT_APP_AUTH_OKTA_TOKEN_TO_SEND_TO_FHIR_SERVER: 'jwt'
       # REACT_APP_AUTH_OKTA_TOKEN_FOR_USER_DETAILS: 'id_token'
       # REACT_APP_AUTH_OKTA_REMOVE_SCOPE_PREFIX: ''
-      # To configure b.well App sign-in, uncomment the following lines and set the
-      # appropriate values, and add 'bwellapp' to REACT_APP_AUTH_PROVIDERS
-      #
-      # REACT_APP_AUTH_BWELLAPP_BASE_URL: 'https://api.dev.icanbwell.com'
-      # REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS: 'Default=<client-key>'
-      # REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME: 'cognito:username'
-      # REACT_APP_AUTH_BWELLAPP_CUSTOM_GROUP: 'cognito:groups'
-      # REACT_APP_AUTH_BWELLAPP_CUSTOM_SCOPE: 'custom:scope'
-      # REACT_APP_AUTH_BWELLAPP_CLIENT_ID: 'bwellapp'
-      # REACT_APP_AUTH_BWELLAPP_TOKEN_FOR_USER_DETAILS: 'jwt'
-      # REACT_APP_AUTH_BWELLAPP_TOKEN_TO_SEND_TO_FHIR_SERVER: 'jwt'
+      # b.well App sign-in (bwellapp is enabled in REACT_APP_AUTH_PROVIDERS above) -
+      # set REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS to a real client key for your dev environment
+      REACT_APP_AUTH_BWELLAPP_BASE_URL: 'https://api.dev.icanbwell.com'
+      REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS: 'Default=<client-key>'
+      REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME: 'cognito:username'
+      REACT_APP_AUTH_BWELLAPP_CUSTOM_GROUP: 'cognito:groups'
+      REACT_APP_AUTH_BWELLAPP_CUSTOM_SCOPE: 'custom:scope'
+      REACT_APP_AUTH_BWELLAPP_CLIENT_ID: 'bwellapp'
+      REACT_APP_AUTH_BWELLAPP_TOKEN_FOR_USER_DETAILS: 'jwt'
+      REACT_APP_AUTH_BWELLAPP_TOKEN_TO_SEND_TO_FHIR_SERVER: 'jwt'
     ports:
       - '5051:5051'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       # b.well App sign-in (bwellapp is enabled in REACT_APP_AUTH_PROVIDERS above) -
       # set REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS to a real client key for your dev environment
       REACT_APP_AUTH_BWELLAPP_BASE_URL: 'https://api.dev.icanbwell.com'
-      REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS: 'Default=<client-key>'
+      REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS: 'Dev=eyJyIjoiY2Zoa2h3ODZvNHdoNWFiOW9kaHgiLCJlbnYiOiJkZXYiLCJraWQiOiJid2VsbF9kZW1vLWRldiJ9'
       REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME: 'cognito:username'
       REACT_APP_AUTH_BWELLAPP_CUSTOM_GROUP: 'cognito:groups'
       REACT_APP_AUTH_BWELLAPP_CUSTOM_SCOPE: 'custom:scope'

--- a/docs/superpowers/plans/2026-08-05-bwell-app-auth.md
+++ b/docs/superpowers/plans/2026-08-05-bwell-app-auth.md
@@ -98,10 +98,18 @@ Run `yarn dev` and confirm the app still boots at `http://localhost:5051` with n
 
 - [ ] **Step 4: Commit**
 
+`.env` is git-ignored and untracked (`git ls-files .env` returns nothing) — it's a
+local-only file each developer maintains themselves, not the shared source of
+truth. Only `docker-compose.yml` is tracked and gets committed:
+
 ```bash
-git add .env docker-compose.yml
-git commit -m "config: replace dangling bwell env vars with b.well App provider config"
+git add docker-compose.yml
+git commit -m "config: add b.well App provider example config, remove dangling bwell case"
 ```
+
+(The `.env` edit from Step 1 stays in your local working copy, uncommitted — that's
+expected and matches how the pre-existing `REACT_APP_AUTH_BWELL_*` values got there
+in the first place.)
 
 ---
 

--- a/docs/superpowers/plans/2026-08-05-bwell-app-auth.md
+++ b/docs/superpowers/plans/2026-08-05-bwell-app-auth.md
@@ -1,0 +1,568 @@
+# Sign In With b.well App Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fourth login option, "Login with b.well App", that authenticates directly against the b.well identity API from the browser (email + password + tenant client key) and produces the same authenticated end-state as the existing Okta/Cognito OIDC flows.
+
+**Architecture:** A standalone credentials-form page (`/bwell-login`) calls a small service function that POSTs to `{BASE_URL}/identity/account/login` with a `clientkey` header, stores the returned JWT the same way the OIDC flows do (`jwt` + `identityProvider` in localStorage, `UserContext` populated via the existing `jwtParser()`), and is deliberately **not** routed through `AuthServiceFactory`/`IAuthService` (those are OIDC/PKCE-shaped; this flow has no redirect or authorization code).
+
+**Tech Stack:** React 19 + TypeScript, Vite, MUI, axios, react-router-dom v7. No test framework exists in this repo — verification is manual (see each task).
+
+**Spec:** `docs/superpowers/specs/2026-08-05-bwell-app-auth-design.md`
+
+## Global Constraints
+
+- Call the b.well identity API directly from the browser — no backend/proxy added to this repo.
+- Support multiple tenant client keys via a dropdown, sourced from `REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS` (comma-separated `Name=key` pairs), matching this repo's existing comma-separated-list convention (`REACT_APP_AUTH_PROVIDERS`).
+- Do not modify `AuthServiceFactory.ts` or `IAuthService.ts` — the new flow bypasses them entirely.
+- `AuthUrlProvider.getAuthInfo('bwellapp')` must not throw — it's called by `jwtParser()` and by `BaseApi`'s request interceptor on every FHIR call, so the full `REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME`/`_CUSTOM_GROUP`/`_CUSTOM_SCOPE`/`_CLIENT_ID`/`_TOKEN_FOR_USER_DETAILS` config block is required even though this flow never calls `getAuthUrlsAsync`.
+- No automated tests — this repo has zero existing test infrastructure (no Jest/Vitest, no `*.test.*` files). Each task instead has explicit manual verification steps.
+- Remove the dangling `REACT_APP_AUTH_BWELL_*` config and `bwell` provider entry (leftover from the removed Cognito-pool case in commit `14a2f67`) as part of this work.
+
+---
+
+### Task 1: Environment configuration
+
+**Files:**
+- Modify: `.env`
+- Modify: `docker-compose.yml`
+
+**Interfaces:**
+- Produces: `import.meta.env.REACT_APP_AUTH_BWELLAPP_BASE_URL`, `REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS`, `REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME`, `REACT_APP_AUTH_BWELLAPP_CUSTOM_GROUP`, `REACT_APP_AUTH_BWELLAPP_CUSTOM_SCOPE`, `REACT_APP_AUTH_BWELLAPP_CLIENT_ID`, `REACT_APP_AUTH_BWELLAPP_TOKEN_FOR_USER_DETAILS`, `REACT_APP_AUTH_BWELLAPP_TOKEN_TO_SEND_TO_FHIR_SERVER` — consumed by Tasks 2, 3, and by the existing `AuthUrlProvider.getAuthInfo()`. `REACT_APP_AUTH_PROVIDERS` now includes `bwellapp` — consumed by `IdentityProviderSelection.tsx` (Task 4).
+
+- [ ] **Step 1: Edit `.env`**
+
+Change the top provider list line from:
+
+```
+REACT_APP_AUTH_PROVIDERS='cognito,okta,bwell'
+```
+
+to:
+
+```
+REACT_APP_AUTH_PROVIDERS='cognito,okta,bwellapp'
+```
+
+Then replace the entire `# bwell provider` block:
+
+```
+# bwell provider
+REACT_APP_AUTH_BWELL_CUSTOM_USERNAME='cognito:username'
+REACT_APP_AUTH_BWELL_CUSTOM_GROUP='cognito:groups'
+REACT_APP_AUTH_BWELL_CUSTOM_SCOPE='custom:scope'
+REACT_APP_AUTH_BWELL_CLIENT_ID='3i43562q02ghinf28av0nqv6di'
+REACT_APP_AUTH_BWELL_REDIRECT_URL='http://localhost:5051/authcallback'
+REACT_APP_AUTH_BWELL_WELL_KNOWN_URL='https://cognito-idp.us-east-1.amazonaws.com/us-east-1_o71QMdxTG/.well-known/openid-configuration'
+REACT_APP_AUTH_BWELL_TOKEN_TO_SEND_TO_FHIR_SERVER='jwt'
+REACT_APP_AUTH_BWELL_TOKEN_FOR_USER_DETAILS='jwt'
+```
+
+with:
+
+```
+# b.well App provider (credentials-form login against the b.well identity API)
+REACT_APP_AUTH_BWELLAPP_BASE_URL='https://api.dev.icanbwell.com'
+REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS='Default=REPLACE_WITH_REAL_CLIENT_KEY'
+REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME='cognito:username'
+REACT_APP_AUTH_BWELLAPP_CUSTOM_GROUP='cognito:groups'
+REACT_APP_AUTH_BWELLAPP_CUSTOM_SCOPE='custom:scope'
+REACT_APP_AUTH_BWELLAPP_CLIENT_ID='bwellapp'
+REACT_APP_AUTH_BWELLAPP_TOKEN_FOR_USER_DETAILS='jwt'
+REACT_APP_AUTH_BWELLAPP_TOKEN_TO_SEND_TO_FHIR_SERVER='jwt'
+```
+
+(`REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS` needs a real client key from whoever owns the b.well identity API for this to work end-to-end in dev — `REPLACE_WITH_REAL_CLIENT_KEY` is a placeholder to swap in Task 3's manual verification.)
+
+- [ ] **Step 2: Edit `docker-compose.yml`**
+
+After the existing commented-out Okta example block (the one ending in `# REACT_APP_AUTH_OKTA_REMOVE_SCOPE_PREFIX: ''`), add a matching commented example for the new provider:
+
+```yaml
+      # To configure b.well App sign-in, uncomment the following lines and set the
+      # appropriate values, and add 'bwellapp' to REACT_APP_AUTH_PROVIDERS
+      #
+      # REACT_APP_AUTH_BWELLAPP_BASE_URL: 'https://api.dev.icanbwell.com'
+      # REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS: 'Default=<client-key>'
+      # REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME: 'cognito:username'
+      # REACT_APP_AUTH_BWELLAPP_CUSTOM_GROUP: 'cognito:groups'
+      # REACT_APP_AUTH_BWELLAPP_CUSTOM_SCOPE: 'custom:scope'
+      # REACT_APP_AUTH_BWELLAPP_CLIENT_ID: 'bwellapp'
+      # REACT_APP_AUTH_BWELLAPP_TOKEN_FOR_USER_DETAILS: 'jwt'
+      # REACT_APP_AUTH_BWELLAPP_TOKEN_TO_SEND_TO_FHIR_SERVER: 'jwt'
+```
+
+- [ ] **Step 3: Manual verification**
+
+Run `yarn dev` and confirm the app still boots at `http://localhost:5051` with no console errors related to env parsing. (The picker will render a generic "Login with Bwellapp" button at this point since Task 4 hasn't relabeled/rewired it yet — that's expected and gets fixed in Task 4.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .env docker-compose.yml
+git commit -m "config: replace dangling bwell env vars with b.well App provider config"
+```
+
+---
+
+### Task 2: b.well App auth service
+
+**Files:**
+- Create: `src/services/BwellAppAuthService.ts`
+
+**Interfaces:**
+- Consumes: `import.meta.env.REACT_APP_AUTH_BWELLAPP_BASE_URL` (Task 1).
+- Produces: `login(email: string, password: string, clientKey: string): Promise<string>` (resolves to the JWT string, throws on failure) and `parseClientKeys(rawClientKeys: string | undefined): { name: string; key: string }[]` — both consumed by Task 3 (`BwellAppLogin.tsx`).
+
+- [ ] **Step 1: Create `src/services/BwellAppAuthService.ts`**
+
+```ts
+import axios from 'axios';
+
+export async function login(
+    email: string,
+    password: string,
+    clientKey: string
+): Promise<string> {
+    const baseUrl = import.meta.env.REACT_APP_AUTH_BWELLAPP_BASE_URL;
+    if (!baseUrl) {
+        throw new Error('REACT_APP_AUTH_BWELLAPP_BASE_URL is not defined');
+    }
+
+    const response = await axios.post(
+        `${baseUrl}/identity/account/login`,
+        { email, password },
+        { headers: { clientkey: clientKey } }
+    );
+
+    const jwtToken = response.data?.accessToken?.jwtToken;
+    if (!jwtToken) {
+        throw new Error('b.well identity API did not return an access token');
+    }
+
+    return jwtToken;
+}
+
+export function parseClientKeys(
+    rawClientKeys: string | undefined
+): { name: string; key: string }[] {
+    if (!rawClientKeys) {
+        return [];
+    }
+    return rawClientKeys
+        .split(',')
+        .map((pair) => pair.trim())
+        .filter((pair) => pair.length > 0)
+        .map((pair) => {
+            const [name, key] = pair.split('=').map((s) => s.trim());
+            return { name, key };
+        })
+        .filter((entry) => entry.name && entry.key);
+}
+```
+
+- [ ] **Step 2: Manual verification**
+
+Run `yarn lint` — must show no new errors/warnings for this file. Run `yarn build` — must complete with no TypeScript errors (this is the closest thing to a type-check test given there's no test runner).
+
+Then sanity-check `parseClientKeys` directly: temporarily open a Node REPL (`node -e "..."` won't work since it's TS/ESM with import.meta — instead open the browser devtools console on any page after `yarn dev` is running, and paste:
+
+```js
+'Default=abc,Second=def'.split(',').map(s=>s.trim()).filter(Boolean).map(p=>{const [n,k]=p.split('=').map(s=>s.trim());return {n,k};})
+```
+
+Confirm it returns `[{n: 'Default', k: 'abc'}, {n: 'Second', k: 'def'}]` — this is the same splitting logic `parseClientKeys` uses, confirming the parsing behavior before it's wired into UI in Task 3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/services/BwellAppAuthService.ts
+git commit -m "feat: add BwellAppAuthService for direct b.well identity API login"
+```
+
+---
+
+### Task 3: b.well App login page and route
+
+**Files:**
+- Create: `src/pages/BwellAppLogin.tsx`
+- Modify: `src/App.tsx`
+
+**Interfaces:**
+- Consumes: `login`, `parseClientKeys` from `src/services/BwellAppAuthService.ts` (Task 2); `REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS` (Task 1); existing `jwtParser()` (`src/utils/jwtParser.ts`), `setLocalData()` (`src/utils/localData.utils.ts`), `UserContext` (`src/context/UserContext.ts`).
+- Produces: default-exported `BwellAppLogin` component, mounted at route `/bwell-login`, expecting `location.state.resourceUrl` (a string, defaulting to `/`) the same way `Auth.tsx` and `IdentityProviderSelection.tsx` already do. Consumed by Task 4 (the picker navigates here).
+
+- [ ] **Step 1: Create `src/pages/BwellAppLogin.tsx`**
+
+```tsx
+import { useContext, useMemo, useState, FormEvent } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+    Typography,
+    Button,
+    Box,
+    TextField,
+    Select,
+    MenuItem,
+    Link,
+    SelectChangeEvent,
+} from '@mui/material';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import UserContext from '../context/UserContext';
+import { setLocalData } from '../utils/localData.utils';
+import { jwtParser } from '../utils/jwtParser';
+import { login, parseClientKeys } from '../services/BwellAppAuthService';
+
+const BwellAppLogin = () => {
+    const { setUserDetails } = useContext(UserContext);
+    const navigate = useNavigate();
+    const location = useLocation();
+    const resourceUrl = location.state?.resourceUrl || '/';
+
+    const clientKeys = useMemo(
+        () => parseClientKeys(import.meta.env.REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS),
+        []
+    );
+
+    const [selectedClientName, setSelectedClientName] = useState<string>(
+        clientKeys[0]?.name || ''
+    );
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [isProcessing, setIsProcessing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleClientChange = (event: SelectChangeEvent) => {
+        setSelectedClientName(event.target.value);
+    };
+
+    const handleSubmit = async (formEvent: FormEvent<HTMLFormElement>) => {
+        formEvent.preventDefault();
+        if (isProcessing) {
+            return;
+        }
+
+        if (clientKeys.length === 0) {
+            setError(
+                'No b.well App client keys are configured (REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS).'
+            );
+            return;
+        }
+
+        const selectedClient =
+            clientKeys.find((c) => c.name === selectedClientName) ?? clientKeys[0];
+
+        setIsProcessing(true);
+        setError(null);
+
+        try {
+            const jwtToken = await login(email, password, selectedClient.key);
+            setLocalData('jwt', jwtToken);
+            setLocalData('identityProvider', 'bwellapp');
+            if (setUserDetails) {
+                setUserDetails(jwtParser());
+            }
+            navigate(resourceUrl);
+        } catch (loginError: any) {
+            const status = loginError?.response?.status;
+            if (status === 401) {
+                setError('Invalid email or password.');
+            } else {
+                setError('Unable to sign in right now. Please try again.');
+            }
+            console.error('b.well App login failed', loginError);
+        } finally {
+            setIsProcessing(false);
+        }
+    };
+
+    return (
+        <div style={{ width: '100%', padding: 0, margin: 0 }}>
+            <Header />
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '60vh',
+                    textAlign: 'center',
+                    minHeight: '85vh',
+                    maxWidth: '400px',
+                    margin: '0 auto',
+                    padding: '0 10px',
+                }}
+            >
+                <Typography variant="h4" gutterBottom>
+                    Sign In With b.well App
+                </Typography>
+                <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, width: '100%' }}>
+                    {clientKeys.length > 1 && (
+                        <Select
+                            fullWidth
+                            value={selectedClientName}
+                            onChange={handleClientChange}
+                            sx={{ mb: 2 }}
+                        >
+                            {clientKeys.map((client) => (
+                                <MenuItem key={client.name} value={client.name}>
+                                    {client.name}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    )}
+                    <TextField
+                        fullWidth
+                        label="Email"
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        sx={{ mb: 2 }}
+                        required
+                    />
+                    <TextField
+                        fullWidth
+                        label="Password"
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        sx={{ mb: 2 }}
+                        required
+                    />
+                    {error && (
+                        <Typography color="error" sx={{ mb: 2 }}>
+                            {error}
+                        </Typography>
+                    )}
+                    <Button
+                        type="submit"
+                        variant="contained"
+                        color="secondary"
+                        sx={{ width: '100%', mb: 2 }}
+                        disabled={isProcessing}
+                    >
+                        {isProcessing ? 'Signing In...' : 'Sign In'}
+                    </Button>
+                    <Link component="button" type="button" onClick={() => navigate('/select-idp')}>
+                        Back
+                    </Link>
+                </Box>
+            </div>
+            <Footer />
+        </div>
+    );
+};
+
+export default BwellAppLogin;
+```
+
+- [ ] **Step 2: Register the route in `src/App.tsx`**
+
+Add the import near the other page imports:
+
+```tsx
+import IdentityProviderSelection from './pages/IdentityProviderSelection';
+import BwellAppLogin from './pages/BwellAppLogin';
+```
+
+Add the route next to `/authcallback` (outside the authenticated-gate `Outlet`, same as `Auth`):
+
+```tsx
+                    <Route key="authcallback" path="/authcallback" element={<Auth />} />
+                    <Route key="bwellLogin" path="/bwell-login" element={<BwellAppLogin />} />
+```
+
+- [ ] **Step 3: Manual verification**
+
+Run `yarn dev`, then in a browser:
+
+1. Navigate directly to `http://localhost:5051/bwell-login`.
+2. Confirm the form renders: Email field, Password field, Sign In button, Back link. Confirm the tenant dropdown is **hidden** (only one `Default=...` key is configured from Task 1).
+3. Open browser devtools Network tab. Submit the form with any email/password.
+4. Confirm a `POST` request fires to `{REACT_APP_AUTH_BWELLAPP_BASE_URL}/identity/account/login` with a `clientkey` request header and a JSON body `{"email": "...", "password": "..."}`. This confirms the wiring is correct even before a real b.well dev account is available:
+   - If the placeholder client key from Task 1 is still in place, expect a 401/403 from the API — confirm the inline error "Invalid email or password." (or "Unable to sign in right now...") renders and the Sign In button re-enables.
+   - Once a real `REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS` value and valid b.well dev credentials are available, repeat this step and confirm: no error shown, `localStorage.jwt` and `localStorage.identityProvider` (`bwellapp`) are set (check via devtools Application tab), and the browser navigates to `/` (or the original resource URL).
+5. Click Back — confirm it navigates to `/select-idp`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/BwellAppLogin.tsx src/App.tsx
+git commit -m "feat: add BwellAppLogin page and /bwell-login route"
+```
+
+---
+
+### Task 4: Wire the picker button
+
+**Files:**
+- Modify: `src/pages/IdentityProviderSelection.tsx`
+
+**Interfaces:**
+- Consumes: route `/bwell-login` (Task 3); `REACT_APP_AUTH_PROVIDERS` containing `bwellapp` (Task 1).
+- Produces: clicking the b.well App button on `/select-idp` navigates to `/bwell-login` with `{ resourceUrl }` in router state, instead of the generic OIDC path.
+
+- [ ] **Step 1: Edit `src/pages/IdentityProviderSelection.tsx`**
+
+Replace the full file contents with:
+
+```tsx
+import { useContext } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Typography, Button, Box } from '@mui/material';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import EnvContext from '../context/EnvironmentContext';
+import { setLocalData } from '../utils/localData.utils';
+
+const PROVIDER_LABELS: Record<string, string> = {
+    bwellapp: 'b.well App',
+};
+
+const IdentityProviderSelection = () => {
+    const env = useContext(EnvContext);
+    const navigate = useNavigate();
+    const location = useLocation();
+    const referringUrl = location.state?.resourceUrl || '/'; // Default to '/' if no referring URL is provided
+
+    console.log('Referring URL:', referringUrl);
+
+    const handleProviderSelection = (provider: string) => {
+        if (provider.toLowerCase() === 'bwellapp') {
+            navigate('/bwell-login', { state: { resourceUrl: referringUrl } });
+            return;
+        }
+        setLocalData('identityProvider', provider);
+        navigate('/authcallback', { state: { resourceUrl: referringUrl } });
+    };
+
+    const providers: string[] = env.AUTH_PROVIDERS.split(',').map((s) => s.trim());
+
+    const getProviderLabel = (provider: string): string =>
+        PROVIDER_LABELS[provider.toLowerCase()] ??
+        provider.charAt(0).toUpperCase() + provider.slice(1);
+
+    return (
+        <div style={{ width: '100%', padding: 0, margin: 0 }}>
+            <Header />
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '60vh',
+                    textAlign: 'center',
+                    minHeight: '85vh',
+                    maxWidth: '600px',
+                    margin: '0 auto',
+                    padding: '0 10px',
+                }}
+            >
+                <Typography variant="h4" gutterBottom>
+                    Select Identity Provider
+                </Typography>
+                <Box sx={{ mt: 4 }}>
+                    {providers.map((provider) => (
+                        <Button
+                            key={provider}
+                            variant="contained"
+                            color={provider.toLowerCase() === 'okta' ? 'primary' : 'secondary'}
+                            sx={{ mb: 2, width: '100%' }}
+                            onClick={() => handleProviderSelection(provider)}
+                        >
+                            Login with {getProviderLabel(provider)}
+                        </Button>
+                    ))}
+                </Box>
+            </div>
+            <Footer />
+        </div>
+    );
+};
+
+export default IdentityProviderSelection;
+```
+
+- [ ] **Step 2: Manual verification**
+
+Run `yarn dev`, clear localStorage, navigate to `http://localhost:5051/` (with no existing session — you should be redirected to `/select-idp`). Confirm three buttons render: "Login with Cognito", "Login with Okta", "Login with b.well App" (not "Login with Bwellapp"). Click "Login with b.well App" and confirm it navigates to `/bwell-login`. Click Cognito or Okta and confirm they still behave as before (navigate to `/authcallback` and redirect to that provider's login).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/IdentityProviderSelection.tsx
+git commit -m "feat: wire b.well App button to /bwell-login instead of the OIDC flow"
+```
+
+---
+
+### Task 5: Logout handling for the b.well App provider
+
+**Files:**
+- Modify: `src/utils/auth.utils.ts`
+
+**Interfaces:**
+- Consumes: `identityProvider` value `'bwellapp'` in localStorage, set by Task 3's `BwellAppLogin`.
+- Produces: `logout()` no longer calls `AuthServiceFactory.getAuthService()` (and therefore never throws `Unsupported identity provider`) when `identityProvider === 'bwellapp'`.
+
+- [ ] **Step 1: Edit `src/utils/auth.utils.ts`**
+
+Change:
+
+```ts
+export const logout = async (setUserDetails?: (_userDetails: any) => void): Promise<void> => {
+    try {
+        const identityProvider = getLocalData('identityProvider');
+        if (identityProvider) {
+            const authService: IAuthService = AuthServiceFactory.getAuthService();
+```
+
+to:
+
+```ts
+export const logout = async (setUserDetails?: (_userDetails: any) => void): Promise<void> => {
+    try {
+        const identityProvider = getLocalData('identityProvider');
+
+        if (identityProvider === 'bwellapp') {
+            // b.well App auth is a direct credentials POST with no OIDC end-session
+            // endpoint - just clear local state instead of building a logout URL.
+            removeAuthData();
+            if (setUserDetails) {
+                setUserDetails(null);
+            }
+            window.location.replace(window.location.origin);
+            return;
+        }
+
+        if (identityProvider) {
+            const authService: IAuthService = AuthServiceFactory.getAuthService();
+```
+
+(Everything else in the function stays as-is — the existing `if (identityProvider)`/`else`/`catch` branches are unchanged, just now unreachable for `'bwellapp'` because of the early `return` above.)
+
+- [ ] **Step 2: Manual verification (full end-to-end)**
+
+With a real `REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS` value and valid b.well dev credentials available (see Task 3 Step 3 note):
+
+1. `yarn dev`, log in via "Login with b.well App" with valid credentials.
+2. Confirm you land on the home page / original resource URL and the app shows you as logged in (check `Footer`/`UserContext`-driven UI, e.g. username display if present).
+3. Navigate to any FHIR resource list page. Open devtools Network tab, confirm the request to the FHIR server carries `Authorization: Bearer <jwt>` and returns a non-401 response (i.e. `BaseApi`'s interceptor correctly resolved `tokenToSendToFhirServer` for `bwellapp` without throwing).
+4. Trigger logout (via whatever UI element calls `logout()` — check `Header.tsx`/`Footer.tsx` for the logout button).
+5. Confirm you're redirected to the app's origin (home page), and that `localStorage` no longer has `jwt`, `id_token`, or `identityProvider` (devtools Application tab).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/auth.utils.ts
+git commit -m "fix: handle logout for the b.well App provider without AuthServiceFactory"
+```
+
+---
+
+## Post-plan follow-ups (not part of this plan, tracked as open questions in the spec)
+
+- Confirm the real JWT claim names returned by `POST /identity/account/login` and correct `REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME`/`_CUSTOM_GROUP`/`_CUSTOM_SCOPE` if they differ from the Cognito-based placeholders used here.
+- Confirm CORS is enabled on the b.well identity API for this app's deployed origins (localhost dev, staging, prod) — required for the browser-direct POST to succeed outside of local dev exceptions.

--- a/docs/superpowers/specs/2026-08-05-bwell-app-auth-design.md
+++ b/docs/superpowers/specs/2026-08-05-bwell-app-auth-design.md
@@ -1,0 +1,219 @@
+# Sign In With b.well App — Design
+
+## Problem
+
+`fhir-server.ui` currently supports two identity providers, both OIDC/PKCE
+authorization-code flows: Okta (`src/services/OktaAuthService.ts`) and Cognito
+(`src/services/CognitoAuthService.ts`), selected via a strategy factory
+(`src/services/AuthServiceFactory.ts`) and rendered as a list of buttons on
+`src/pages/IdentityProviderSelection.tsx`.
+
+There used to be a third provider, `bwell` — not a distinct auth mechanism, just a
+b.well-owned Cognito user pool reusing `CognitoAuthService`. Its factory case was
+removed in commit `14a2f67` ("Remove bwell case from AuthServiceFactory"), but the
+env vars (`REACT_APP_AUTH_BWELL_*`) and the `bwell` entry in
+`REACT_APP_AUTH_PROVIDERS` were left in `.env`. The picker currently still renders a
+"Login with Bwell" button that throws `Unsupported identity provider: bwell` when
+clicked — a pre-existing bug this design incidentally fixes.
+
+We want a genuinely new option: "Sign in with b.well App", matching what
+`baileyai-skills-service` calls the same thing. There, despite the name, it is **not**
+a mobile-app deep-link/QR/push flow — it's a credentials-form (email + password) that
+the backend proxies to `POST {BWELL_API_BASE_URL}/identity/account/login` with a
+`clientkey` header, returning a JWT (`accessToken.jwtToken`). It's wired via an
+`AuthMethodProvider` strategy registry, and the frontend renders a client (tenant)
+dropdown sourced from `BWELL_CLIENT_KEYS` when multiple tenants are configured.
+
+`fhir-server.ui` has no backend of its own (pure Vite/React SPA — confirmed via
+`package.json` and repo structure), so the credentials POST has to happen directly
+from the browser rather than through a proxy like baileyai's `AppLoginManager`.
+
+## Goal
+
+Add "Login with b.well App" as a fourth option on the identity provider picker. It
+collects email + password (+ tenant selection when multiple client keys are
+configured) and authenticates directly against the b.well identity API from the
+browser, producing the same end state as the existing OIDC flows: a `jwt` in
+localStorage, `identityProvider` set, and `UserContext` populated — so every other
+part of the app (FHIR API calls via `BaseApi`, logout, admin-scope checks) keeps
+working unmodified.
+
+## Non-goals
+
+- Building an actual mobile-app deep-link/QR-code/push-notification flow. The label
+  says "b.well App" but, per baileyai's implementation, the mechanism is a plain
+  credentials POST — we're matching that, not inventing the deep-link flow the name
+  might suggest.
+- Adding a backend/proxy service to this repo. Decided: call the b.well identity API
+  directly from the browser.
+- A generic pluggable auth-provider registry (like baileyai's `AuthMethodRegistry`).
+  With only one non-OIDC provider, forcing it through a new abstraction layer is not
+  justified — see "Existing abstractions, deliberately untouched" below.
+- Editing/removing the Okta or Cognito flows.
+
+## Existing precedent / abstractions, deliberately untouched
+
+- `IAuthService` (`src/services/IAuthService.ts`) is OIDC/PKCE-shaped:
+  `getLoginUrlAsync` (build a redirect URL), `fetchTokenAsync` (exchange an
+  authorization `code` for tokens), `getLogoutUrlAsync`. A credentials POST has no
+  redirect and no `code` — shoehorning it into this interface would distort the
+  abstraction for a single caller. `AuthServiceFactory.ts` is **not modified**; the
+  new flow bypasses it entirely.
+- `AuthUrlProvider.getAuthInfo(provider)` (`src/utils/authUrlProvider.ts`) is a
+  provider-keyed config resolver used in two places that matter here even though the
+  new flow skips OIDC:
+  - `jwtParser()` (`src/utils/jwtParser.ts`) calls it to know which claims to read
+    (`customUserName`, `customGroup`, `customScope`) and which stored token
+    (`tokenForUserDetails`) to decode.
+  - `BaseApi.requestInterceptor` (`src/api/baseApi.ts:108-116`) calls it on **every**
+    FHIR API request to decide which stored token (`tokenToSendToFhirServer`) to send
+    as the `Authorization` header.
+
+  Both throw if the five required keys
+  (`CUSTOM_USERNAME`/`CUSTOM_GROUP`/`CUSTOM_SCOPE`/`CLIENT_ID`/`TOKEN_FOR_USER_DETAILS`)
+  aren't defined for the given provider prefix. **This means the new provider still
+  needs a full `REACT_APP_AUTH_BWELLAPP_*` config block even though it never touches
+  `getAuthUrlsAsync` (the OIDC-URL half of the same class)** — otherwise every FHIR
+  request after a successful b.well-app login throws inside the axios interceptor.
+
+## Design
+
+### 1. Config — new env vars (replace the dangling `bwell` ones)
+
+In `.env` (and equivalent docker-compose/env-doc files):
+
+```
+REACT_APP_AUTH_PROVIDERS='cognito,okta,bwellapp'   # was '...,bwell'
+
+# b.well App provider
+REACT_APP_AUTH_BWELLAPP_BASE_URL='https://api.dev.icanbwell.com'
+REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS='Default=<client-key>'   # comma-separated Name=key pairs
+REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME='cognito:username'   # placeholder — see Open Questions
+REACT_APP_AUTH_BWELLAPP_CUSTOM_GROUP='cognito:groups'        # placeholder — see Open Questions
+REACT_APP_AUTH_BWELLAPP_CUSTOM_SCOPE='custom:scope'          # placeholder — see Open Questions
+REACT_APP_AUTH_BWELLAPP_CLIENT_ID='bwellapp'                 # required by getAuthInfo(); unused by this flow otherwise
+REACT_APP_AUTH_BWELLAPP_TOKEN_FOR_USER_DETAILS='jwt'
+REACT_APP_AUTH_BWELLAPP_TOKEN_TO_SEND_TO_FHIR_SERVER='jwt'
+```
+
+Remove `REACT_APP_AUTH_BWELL_*` (the old, dangling Cognito-pool config) as cleanup.
+
+`REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS` format matches baileyai's
+`Name=key,Name2=key2` convention and this repo's existing comma-separated-list
+convention (`REACT_APP_AUTH_PROVIDERS`). Parsed client-side into `{name, key}[]` —
+no separate `/bwell-clients` endpoint is needed since there's no backend to hide the
+keys behind (they're tenant identifiers, not secrets — see Security below).
+
+### 2. `src/pages/IdentityProviderSelection.tsx`
+
+Special-case `bwellapp` in `handleProviderSelection` (or a new dedicated handler):
+instead of `setLocalData('identityProvider', provider)` + navigate to
+`/authcallback`, navigate to `/bwell-login` with `resourceUrl` in router state
+(matching how `referringUrl` is already threaded through). Label rendering: add an
+explicit case so the button reads "Login with b.well App" rather than the generic
+`provider.charAt(0).toUpperCase() + provider.slice(1)` (which would render "Login
+with Bwellapp").
+
+### 3. `src/pages/BwellAppLogin.tsx` (new)
+
+Page shell matching existing pages (`Header`/`Footer`, centered column like
+`IdentityProviderSelection`). Contents:
+
+- Parses `REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS` into a `{name, key}[]` list.
+  - 0 entries → configuration error, show a message (shouldn't happen if
+    `bwellapp` is in `REACT_APP_AUTH_PROVIDERS` at all).
+  - 1 entry → skip the dropdown, use that key silently.
+  - 2+ entries → render an MUI `<Select>` of tenant names, defaulting to the first.
+- Email + password `<TextField>`s, a submit `<Button>`, and a "Back" link to
+  `/select-idp`.
+- `isProcessing`/`error` state mirroring `Auth.tsx`'s pattern.
+- On submit: calls `BwellAppAuthService.login(email, password, selectedClientKey)`.
+  - Success: `setLocalData('jwt', accessToken)`, `setLocalData('identityProvider',
+    'bwellapp')`, `setUserDetails(jwtParser())`, `navigate(resourceUrl)` (from router
+    state, defaulting to `/`) — same sequence `Auth.tsx`'s `fetchTokenAsync` already
+    does for the OIDC flows.
+  - Failure: inline error message (see Error handling below); form stays populated
+    except password.
+
+### 4. `src/services/BwellAppAuthService.ts` (new)
+
+Plain async function, not a class implementing `IAuthService` (see "deliberately
+untouched" above):
+
+```ts
+export async function login(email: string, password: string, clientKey: string): Promise<string> {
+    const baseUrl = import.meta.env.REACT_APP_AUTH_BWELLAPP_BASE_URL;
+    const response = await axios.post(
+        `${baseUrl}/identity/account/login`,
+        { email, password },
+        { headers: { clientkey: clientKey } }
+    );
+    const jwtToken = response.data?.accessToken?.jwtToken;
+    if (!jwtToken) {
+        throw new Error('b.well identity API did not return an access token');
+    }
+    return jwtToken;
+}
+```
+
+Uses a bare `axios.post`, not `BaseApi`/`FhirApi` — this call targets the b.well
+identity API host, not the configured FHIR server, and must not go through
+`BaseApi`'s Bearer-token request interceptor (there's no token yet at this point).
+
+### 5. `src/App.tsx`
+
+Register the new route: `/bwell-login` → `<BwellAppLogin />`, alongside the existing
+`/select-idp` and `/authcallback` routes.
+
+### 6. `src/utils/auth.utils.ts` — `logout()`
+
+Current `logout()` always calls `AuthServiceFactory.getAuthService().getLogoutUrlAsync()`
+and redirects to an OIDC end-session endpoint. There is no such endpoint for
+`bwellapp`. Add a branch: if `identityProvider === 'bwellapp'`, skip
+`AuthServiceFactory` entirely — just `removeAuthData()`, clear user context, and
+`window.location.replace(window.location.origin)`, i.e. the same fallback path
+already used today when no `identityProvider` is set at all.
+
+## Error handling
+
+- **401 (invalid credentials)**: inline form message "Invalid email or password."
+- **Network error / non-401 failure**: inline form message "Unable to sign in right
+  now. Please try again." No automatic retry — resubmission is user-initiated, same
+  as any login form.
+- **Missing/misconfigured env** (`BASE_URL` or `CLIENT_KEYS` absent): fail fast with a
+  clear on-page message rather than a silent broken button, consistent with how a
+  misconfigured OIDC provider currently surfaces as a thrown error in
+  `AuthUrlProvider`.
+
+## Security
+
+- `clientkey` values ship in the frontend bundle via `REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS`.
+  This is acceptable: they're tenant identifiers, not user secrets — the same trust
+  model as `REACT_APP_AUTH_OKTA_CLIENT_ID` already being public in this app.
+- The b.well identity API must allow CORS from this app's origin(s) for the direct
+  browser POST to succeed. This is an infra/backend-side change **outside this repo**
+  — flag to whoever owns `api.<env>.icanbwell.com` before this ships; if CORS can't be
+  granted, the fallback is the backend-proxy alternative that was considered and
+  rejected for scope reasons in this round.
+
+## Testing
+
+- Unit test `BwellAppAuthService.login()`: success path (extracts `jwtToken`), 401
+  path (throws), malformed-response path (missing `accessToken.jwtToken`, throws).
+- Component test for `BwellAppLogin.tsx`: renders dropdown only when 2+ client keys
+  configured; submit disabled while `isProcessing`; error message shown on failed
+  login; successful login calls `navigate` with the expected resource URL.
+- Manual verification against a real dev-environment b.well identity API account
+  before merging, specifically to confirm the JWT claim names (see Open Questions).
+
+## Open questions
+
+1. **JWT claim names**: `REACT_APP_AUTH_BWELLAPP_CUSTOM_USERNAME`/`_CUSTOM_GROUP`/
+   `_CUSTOM_SCOPE` are placeholders (reused from the old `bwell` Cognito config) —
+   the actual claim names issued by `POST /identity/account/login`'s JWT are not yet
+   confirmed. Needs a real token from that endpoint to verify before shipping;
+   otherwise `username`/`isAdmin`/scope-based UI gating may silently be wrong even
+   though login "succeeds."
+2. **CORS**: needs confirmation from whoever owns the b.well identity API that
+   browser-origin CORS is (or can be) enabled for this app's deployed origins
+   (localhost dev, staging, prod).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { ThemeContextProvider } from './context/ThemeContext';
 import { TUserDetails } from './types/baseTypes';
 import { jwtParser } from './utils/jwtParser';
 import IdentityProviderSelection from './pages/IdentityProviderSelection';
+import BwellAppLogin from './pages/BwellAppLogin';
 import { useLocation } from 'react-router-dom';
 import NotFoundPage from './pages/NotFoundPage';
 import AccessDenied from './pages/AccessDenied';
@@ -50,6 +51,7 @@ function App(): React.ReactElement {
                         <Route key="identityProvider" path="/select-idp" element={<IdentityProviderSelection />} />
                     </Route>
                     <Route key="authcallback" path="/authcallback" element={<Auth />} />
+                    <Route key="bwellLogin" path="/bwell-login" element={<BwellAppLogin />} />
                     <Route
                         element={
                             userDetails ? (

--- a/src/pages/BwellAppLogin.tsx
+++ b/src/pages/BwellAppLogin.tsx
@@ -9,6 +9,8 @@ import {
     MenuItem,
     Link,
     SelectChangeEvent,
+    FormControl,
+    InputLabel,
 } from '@mui/material';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
@@ -138,19 +140,22 @@ const BwellAppLogin = () => {
                     </Typography>
                 ) : (
                     <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, width: '100%' }}>
-                        {clientKeys.length > 1 && (
-                            <Select
-                                fullWidth
-                                value={selectedClientName}
-                                onChange={handleClientChange}
-                                sx={{ mb: 2 }}
-                            >
-                                {clientKeys.map((client) => (
-                                    <MenuItem key={client.name} value={client.name}>
-                                        {client.name}
-                                    </MenuItem>
-                                ))}
-                            </Select>
+                        {clientKeys.length > 0 && (
+                            <FormControl fullWidth sx={{ mb: 2 }}>
+                                <InputLabel id="bwell-tenant-label">Tenant</InputLabel>
+                                <Select
+                                    labelId="bwell-tenant-label"
+                                    label="Tenant"
+                                    value={selectedClientName}
+                                    onChange={handleClientChange}
+                                >
+                                    {clientKeys.map((client) => (
+                                        <MenuItem key={client.name} value={client.name}>
+                                            {client.name}
+                                        </MenuItem>
+                                    ))}
+                                </Select>
+                            </FormControl>
                         )}
                         <TextField
                             fullWidth
@@ -178,7 +183,7 @@ const BwellAppLogin = () => {
                         <Button
                             type="submit"
                             variant="contained"
-                            color="secondary"
+                            color="primary"
                             sx={{ width: '100%', mb: 2 }}
                             disabled={isProcessing}
                         >

--- a/src/pages/BwellAppLogin.tsx
+++ b/src/pages/BwellAppLogin.tsx
@@ -1,0 +1,160 @@
+import { useContext, useMemo, useState, FormEvent } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+    Typography,
+    Button,
+    Box,
+    TextField,
+    Select,
+    MenuItem,
+    Link,
+    SelectChangeEvent,
+} from '@mui/material';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import UserContext from '../context/UserContext';
+import { setLocalData } from '../utils/localData.utils';
+import { jwtParser } from '../utils/jwtParser';
+import { login, parseClientKeys } from '../services/BwellAppAuthService';
+
+const BwellAppLogin = () => {
+    const { setUserDetails } = useContext(UserContext);
+    const navigate = useNavigate();
+    const location = useLocation();
+    const resourceUrl = location.state?.resourceUrl || '/';
+
+    const clientKeys = useMemo(
+        () => parseClientKeys(import.meta.env.REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS),
+        []
+    );
+
+    const [selectedClientName, setSelectedClientName] = useState<string>(
+        clientKeys[0]?.name || ''
+    );
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [isProcessing, setIsProcessing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleClientChange = (event: SelectChangeEvent) => {
+        setSelectedClientName(event.target.value);
+    };
+
+    const handleSubmit = async (formEvent: FormEvent<HTMLFormElement>) => {
+        formEvent.preventDefault();
+        if (isProcessing) {
+            return;
+        }
+
+        if (clientKeys.length === 0) {
+            setError(
+                'No b.well App client keys are configured (REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS).'
+            );
+            return;
+        }
+
+        const selectedClient =
+            clientKeys.find((c) => c.name === selectedClientName) ?? clientKeys[0];
+
+        setIsProcessing(true);
+        setError(null);
+
+        try {
+            const jwtToken = await login(email, password, selectedClient.key);
+            setLocalData('jwt', jwtToken);
+            setLocalData('identityProvider', 'bwellapp');
+            if (setUserDetails) {
+                setUserDetails(jwtParser());
+            }
+            navigate(resourceUrl);
+        } catch (loginError: any) {
+            const status = loginError?.response?.status;
+            if (status === 401) {
+                setError('Invalid email or password.');
+            } else {
+                setError('Unable to sign in right now. Please try again.');
+            }
+            console.error('b.well App login failed', loginError);
+        } finally {
+            setIsProcessing(false);
+        }
+    };
+
+    return (
+        <div style={{ width: '100%', padding: 0, margin: 0 }}>
+            <Header />
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '60vh',
+                    textAlign: 'center',
+                    minHeight: '85vh',
+                    maxWidth: '400px',
+                    margin: '0 auto',
+                    padding: '0 10px',
+                }}
+            >
+                <Typography variant="h4" gutterBottom>
+                    Sign In With b.well App
+                </Typography>
+                <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, width: '100%' }}>
+                    {clientKeys.length > 1 && (
+                        <Select
+                            fullWidth
+                            value={selectedClientName}
+                            onChange={handleClientChange}
+                            sx={{ mb: 2 }}
+                        >
+                            {clientKeys.map((client) => (
+                                <MenuItem key={client.name} value={client.name}>
+                                    {client.name}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    )}
+                    <TextField
+                        fullWidth
+                        label="Email"
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        sx={{ mb: 2 }}
+                        required
+                    />
+                    <TextField
+                        fullWidth
+                        label="Password"
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        sx={{ mb: 2 }}
+                        required
+                    />
+                    {error && (
+                        <Typography color="error" sx={{ mb: 2 }}>
+                            {error}
+                        </Typography>
+                    )}
+                    <Button
+                        type="submit"
+                        variant="contained"
+                        color="secondary"
+                        sx={{ width: '100%', mb: 2 }}
+                        disabled={isProcessing}
+                    >
+                        {isProcessing ? 'Signing In...' : 'Sign In'}
+                    </Button>
+                    <Link component="button" type="button" onClick={() => navigate('/select-idp')}>
+                        Back
+                    </Link>
+                </Box>
+            </div>
+            <Footer />
+        </div>
+    );
+};
+
+export default BwellAppLogin;

--- a/src/pages/BwellAppLogin.tsx
+++ b/src/pages/BwellAppLogin.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState, FormEvent } from 'react';
+import { useContext, useEffect, useMemo, useState, FormEvent } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
     Typography,
@@ -13,7 +13,7 @@ import {
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import UserContext from '../context/UserContext';
-import { setLocalData } from '../utils/localData.utils';
+import { getLocalData, setLocalData } from '../utils/localData.utils';
 import { jwtParser } from '../utils/jwtParser';
 import { removeAuthData } from '../utils/auth.utils';
 import { login, parseClientKeys } from '../services/BwellAppAuthService';
@@ -50,6 +50,13 @@ const BwellAppLogin = () => {
     const [isProcessing, setIsProcessing] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
+    useEffect(() => {
+        if (getLocalData('jwt')) {
+            navigate(resourceUrl);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     const handleClientChange = (event: SelectChangeEvent) => {
         setSelectedClientName(event.target.value);
     };
@@ -78,6 +85,7 @@ const BwellAppLogin = () => {
             setLocalData('identityProvider', 'bwellapp');
             const userDetails = jwtParser();
             if (!userDetails) {
+                removeAuthData();
                 setError(
                     'Signed in, but the session could not be established. Please contact support.'
                 );
@@ -179,7 +187,7 @@ const BwellAppLogin = () => {
                         <Link
                             component="button"
                             type="button"
-                            onClick={() => navigate('/select-idp')}
+                            onClick={() => navigate('/select-idp', { state: { resourceUrl } })}
                         >
                             Back
                         </Link>

--- a/src/pages/BwellAppLogin.tsx
+++ b/src/pages/BwellAppLogin.tsx
@@ -15,7 +15,11 @@ import Footer from '../components/Footer';
 import UserContext from '../context/UserContext';
 import { setLocalData } from '../utils/localData.utils';
 import { jwtParser } from '../utils/jwtParser';
+import { removeAuthData } from '../utils/auth.utils';
 import { login, parseClientKeys } from '../services/BwellAppAuthService';
+
+const CLIENT_KEYS_MISSING_MESSAGE =
+    'No b.well App client keys are configured (REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS).';
 
 const BwellAppLogin = () => {
     const { setUserDetails } = useContext(UserContext);
@@ -27,6 +31,16 @@ const BwellAppLogin = () => {
         () => parseClientKeys(import.meta.env.REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS),
         []
     );
+
+    const configError = useMemo(() => {
+        if (!import.meta.env.REACT_APP_AUTH_BWELLAPP_BASE_URL) {
+            return 'b.well App sign-in is not configured (missing base URL).';
+        }
+        if (clientKeys.length === 0) {
+            return CLIENT_KEYS_MISSING_MESSAGE;
+        }
+        return null;
+    }, [clientKeys]);
 
     const [selectedClientName, setSelectedClientName] = useState<string>(
         clientKeys[0]?.name || ''
@@ -47,9 +61,7 @@ const BwellAppLogin = () => {
         }
 
         if (clientKeys.length === 0) {
-            setError(
-                'No b.well App client keys are configured (REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS).'
-            );
+            setError(CLIENT_KEYS_MISSING_MESSAGE);
             return;
         }
 
@@ -61,20 +73,32 @@ const BwellAppLogin = () => {
 
         try {
             const jwtToken = await login(email, password, selectedClient.key);
+            removeAuthData();
             setLocalData('jwt', jwtToken);
             setLocalData('identityProvider', 'bwellapp');
+            const userDetails = jwtParser();
+            if (!userDetails) {
+                setError(
+                    'Signed in, but the session could not be established. Please contact support.'
+                );
+                return;
+            }
             if (setUserDetails) {
-                setUserDetails(jwtParser());
+                setUserDetails(userDetails);
             }
             navigate(resourceUrl);
         } catch (loginError: any) {
             const status = loginError?.response?.status;
-            if (status === 401) {
-                setError('Invalid email or password.');
+            if (status === 400 || status === 401 || status === 403) {
+                setError(loginError?.response?.data?.message || 'Invalid email or password.');
             } else {
                 setError('Unable to sign in right now. Please try again.');
             }
-            console.error('b.well App login failed', loginError);
+            console.error('b.well App login failed', {
+                message: loginError?.message,
+                status: loginError?.response?.status,
+            });
+            setPassword('');
         } finally {
             setIsProcessing(false);
         }
@@ -100,57 +124,67 @@ const BwellAppLogin = () => {
                 <Typography variant="h4" gutterBottom>
                     Sign In With b.well App
                 </Typography>
-                <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, width: '100%' }}>
-                    {clientKeys.length > 1 && (
-                        <Select
+                {configError ? (
+                    <Typography color="error" sx={{ mt: 4 }}>
+                        {configError}
+                    </Typography>
+                ) : (
+                    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, width: '100%' }}>
+                        {clientKeys.length > 1 && (
+                            <Select
+                                fullWidth
+                                value={selectedClientName}
+                                onChange={handleClientChange}
+                                sx={{ mb: 2 }}
+                            >
+                                {clientKeys.map((client) => (
+                                    <MenuItem key={client.name} value={client.name}>
+                                        {client.name}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        )}
+                        <TextField
                             fullWidth
-                            value={selectedClientName}
-                            onChange={handleClientChange}
+                            label="Email"
+                            type="email"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
                             sx={{ mb: 2 }}
+                            required
+                        />
+                        <TextField
+                            fullWidth
+                            label="Password"
+                            type="password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            sx={{ mb: 2 }}
+                            required
+                        />
+                        {error && (
+                            <Typography color="error" sx={{ mb: 2 }}>
+                                {error}
+                            </Typography>
+                        )}
+                        <Button
+                            type="submit"
+                            variant="contained"
+                            color="secondary"
+                            sx={{ width: '100%', mb: 2 }}
+                            disabled={isProcessing}
                         >
-                            {clientKeys.map((client) => (
-                                <MenuItem key={client.name} value={client.name}>
-                                    {client.name}
-                                </MenuItem>
-                            ))}
-                        </Select>
-                    )}
-                    <TextField
-                        fullWidth
-                        label="Email"
-                        type="email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        sx={{ mb: 2 }}
-                        required
-                    />
-                    <TextField
-                        fullWidth
-                        label="Password"
-                        type="password"
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        sx={{ mb: 2 }}
-                        required
-                    />
-                    {error && (
-                        <Typography color="error" sx={{ mb: 2 }}>
-                            {error}
-                        </Typography>
-                    )}
-                    <Button
-                        type="submit"
-                        variant="contained"
-                        color="secondary"
-                        sx={{ width: '100%', mb: 2 }}
-                        disabled={isProcessing}
-                    >
-                        {isProcessing ? 'Signing In...' : 'Sign In'}
-                    </Button>
-                    <Link component="button" type="button" onClick={() => navigate('/select-idp')}>
-                        Back
-                    </Link>
-                </Box>
+                            {isProcessing ? 'Signing In...' : 'Sign In'}
+                        </Button>
+                        <Link
+                            component="button"
+                            type="button"
+                            onClick={() => navigate('/select-idp')}
+                        >
+                            Back
+                        </Link>
+                    </Box>
+                )}
             </div>
             <Footer />
         </div>

--- a/src/pages/IdentityProviderSelection.tsx
+++ b/src/pages/IdentityProviderSelection.tsx
@@ -58,7 +58,7 @@ const IdentityProviderSelection = () => {
                         <Button
                             key={provider}
                             variant="contained"
-                            color={provider.toLowerCase() === 'okta' ? 'primary' : 'secondary'}
+                            color="primary"
                             sx={{ mb: 2, width: '100%' }}
                             onClick={() => handleProviderSelection(provider)}
                         >

--- a/src/pages/IdentityProviderSelection.tsx
+++ b/src/pages/IdentityProviderSelection.tsx
@@ -6,6 +6,10 @@ import Footer from '../components/Footer';
 import EnvContext from '../context/EnvironmentContext';
 import { setLocalData } from '../utils/localData.utils';
 
+const PROVIDER_LABELS: Record<string, string> = {
+    bwellapp: 'b.well App',
+};
+
 const IdentityProviderSelection = () => {
     const env = useContext(EnvContext);
     const navigate = useNavigate();
@@ -15,11 +19,19 @@ const IdentityProviderSelection = () => {
     console.log('Referring URL:', referringUrl);
 
     const handleProviderSelection = (provider: string) => {
+        if (provider.toLowerCase() === 'bwellapp') {
+            navigate('/bwell-login', { state: { resourceUrl: referringUrl } });
+            return;
+        }
         setLocalData('identityProvider', provider);
         navigate('/authcallback', { state: { resourceUrl: referringUrl } });
     };
 
     const providers: string[] = env.AUTH_PROVIDERS.split(',').map((s) => s.trim());
+
+    const getProviderLabel = (provider: string): string =>
+        PROVIDER_LABELS[provider.toLowerCase()] ??
+        provider.charAt(0).toUpperCase() + provider.slice(1);
 
     return (
         <div style={{ width: '100%', padding: 0, margin: 0 }}>
@@ -35,7 +47,7 @@ const IdentityProviderSelection = () => {
                     minHeight: '85vh',
                     maxWidth: '600px',
                     margin: '0 auto',
-                    padding: '0 10px'
+                    padding: '0 10px',
                 }}
             >
                 <Typography variant="h4" gutterBottom>
@@ -50,7 +62,7 @@ const IdentityProviderSelection = () => {
                             sx={{ mb: 2, width: '100%' }}
                             onClick={() => handleProviderSelection(provider)}
                         >
-                            Login with {provider.charAt(0).toUpperCase() + provider.slice(1)}
+                            Login with {getProviderLabel(provider)}
                         </Button>
                     ))}
                 </Box>

--- a/src/services/BwellAppAuthService.ts
+++ b/src/services/BwellAppAuthService.ts
@@ -35,8 +35,14 @@ export function parseClientKeys(
         .map((pair) => pair.trim())
         .filter((pair) => pair.length > 0)
         .map((pair) => {
-            const [name, key] = pair.split('=').map((s) => s.trim());
-            return { name, key };
+            const equalsIndex = pair.indexOf('=');
+            if (equalsIndex < 0) {
+                return { name: '', key: '' };
+            }
+            return {
+                name: pair.slice(0, equalsIndex).trim(),
+                key: pair.slice(equalsIndex + 1).trim(),
+            };
         })
         .filter((entry) => entry.name && entry.key);
 }

--- a/src/services/BwellAppAuthService.ts
+++ b/src/services/BwellAppAuthService.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+
+export async function login(
+    email: string,
+    password: string,
+    clientKey: string
+): Promise<string> {
+    const baseUrl = import.meta.env.REACT_APP_AUTH_BWELLAPP_BASE_URL;
+    if (!baseUrl) {
+        throw new Error('REACT_APP_AUTH_BWELLAPP_BASE_URL is not defined');
+    }
+
+    const response = await axios.post(
+        `${baseUrl}/identity/account/login`,
+        { email, password },
+        { headers: { clientkey: clientKey } }
+    );
+
+    const jwtToken = response.data?.accessToken?.jwtToken;
+    if (!jwtToken) {
+        throw new Error('b.well identity API did not return an access token');
+    }
+
+    return jwtToken;
+}
+
+export function parseClientKeys(
+    rawClientKeys: string | undefined
+): { name: string; key: string }[] {
+    if (!rawClientKeys) {
+        return [];
+    }
+    return rawClientKeys
+        .split(',')
+        .map((pair) => pair.trim())
+        .filter((pair) => pair.length > 0)
+        .map((pair) => {
+            const [name, key] = pair.split('=').map((s) => s.trim());
+            return { name, key };
+        })
+        .filter((entry) => entry.name && entry.key);
+}

--- a/src/utils/auth.utils.ts
+++ b/src/utils/auth.utils.ts
@@ -13,6 +13,18 @@ export const removeAuthData = (): void => {
 export const logout = async (setUserDetails?: (_userDetails: any) => void): Promise<void> => {
     try {
         const identityProvider = getLocalData('identityProvider');
+
+        if (identityProvider === 'bwellapp') {
+            // b.well App auth is a direct credentials POST with no OIDC end-session
+            // endpoint - just clear local state instead of building a logout URL.
+            removeAuthData();
+            if (setUserDetails) {
+                setUserDetails(null);
+            }
+            window.location.replace(window.location.origin);
+            return;
+        }
+
         if (identityProvider) {
             const authService: IAuthService = AuthServiceFactory.getAuthService();
             // Construct full logout URL


### PR DESCRIPTION
## Summary
- Adds a fourth login option, "Sign In With b.well App", that authenticates directly against the b.well identity API from the browser (email + password + tenant client key) via `POST {BASE_URL}/identity/account/login`, since this SPA has no backend of its own to proxy the request (unlike baileyai-skills-service's equivalent flow).
- Deliberately does **not** route through the existing `AuthServiceFactory`/`IAuthService` OIDC abstraction — that's PKCE/redirect-shaped and this flow has no redirect or authorization code.
- Cleans up a pre-existing bug: the dangling `bwell` provider entry (leftover from commit `14a2f67`) that rendered a broken "Login with Bwell" button.
- Design spec: `docs/superpowers/specs/2026-08-05-bwell-app-auth-design.md`
- Implementation plan: `docs/superpowers/plans/2026-08-05-bwell-app-auth.md`

## Changes
- `src/services/BwellAppAuthService.ts` (new) — `login()` + `parseClientKeys()`
- `src/pages/BwellAppLogin.tsx` (new) — credentials form + tenant dropdown, wired at `/bwell-login`
- `src/pages/IdentityProviderSelection.tsx` — routes the new provider to `/bwell-login` instead of the OIDC flow
- `src/utils/auth.utils.ts` — `logout()` handles the new provider without calling `AuthServiceFactory`
- `.env` (local, untracked) / `docker-compose.yml` — new `REACT_APP_AUTH_BWELLAPP_*` config, replacing the dangling `bwell` block
- `.gitignore` — ignores the scratch workspace and Playwright verification artifacts used during development

## Open questions (flagged in the spec, not blockers for this PR)
1. The JWT claim names (`CUSTOM_USERNAME`/`CUSTOM_GROUP`/`CUSTOM_SCOPE`) are placeholders copied from the old Cognito-based config — need verification against a real b.well identity API token before this is fully production-ready.
2. CORS on the b.well identity API needs confirmation for staging/prod origins (localhost dev is confirmed working — a real 400 response was observed rather than a CORS rejection).

## Test plan
This repo has no automated test suite. Verification was manual/Playwright-driven per task, plus `yarn build`/`yarn lint`:
- [ ] Confirm the "Login with b.well App" button appears on `/select-idp` and navigates to `/bwell-login`
- [ ] Confirm the credentials form renders (email/password, tenant dropdown only when 2+ client keys configured)
- [ ] Submit with a real b.well dev account once a real `REACT_APP_AUTH_BWELLAPP_CLIENT_KEYS` value is available; confirm successful login lands on the original resource URL
- [ ] Confirm invalid credentials show "Invalid email or password." and the password field clears
- [ ] Confirm logout works without throwing (no `AuthServiceFactory` "Unsupported identity provider" error)
- [ ] Confirm FHIR API calls after a b.well-app login carry a valid `Authorization` header (no 401s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)