### PR TITLE
PHR-3351 Update postcss and brace-expansion to patch high-severity CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "globals": "^17.6.0",
     "jwt-decode": "^4.0.0",
     "lru-cache": "^11.5.0",
-    "postcss": "^8.5.23",
+    "postcss": "^8.5.25",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-preset-env": "^11.3.0",
     "react": "^19.2.6",
@@ -60,6 +60,10 @@
   },
   "devDependencies": {
     "prettier": "^3.8.3"
+  },
+  "resolutions": {
+    "postcss@npm:^8.5.15": "^8.5.25",
+    "brace-expansion@npm:^5.0.5": "^5.0.9"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2418,12 +2418,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+"brace-expansion@npm:^5.0.9":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 
@@ -3247,7 +3247,7 @@ __metadata:
     globals: "npm:^17.6.0"
     jwt-decode: "npm:^4.0.0"
     lru-cache: "npm:^11.5.0"
-    postcss: "npm:^8.5.23"
+    postcss: "npm:^8.5.25"
     postcss-flexbugs-fixes: "npm:^5.0.2"
     postcss-preset-env: "npm:^11.3.0"
     prettier: "npm:^3.8.3"
@@ -4239,15 +4239,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.16":
   version: 3.3.17
   resolution: "nanoid@npm:3.3.17"
@@ -4909,25 +4900,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.15":
-  version: 8.5.15
-  resolution: "postcss@npm:8.5.15"
-  dependencies:
-    nanoid: "npm:^3.3.12"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.23":
-  version: 8.5.23
-  resolution: "postcss@npm:8.5.23"
+"postcss@npm:^8.5.25":
+  version: 8.5.25
+  resolution: "postcss@npm:8.5.25"
   dependencies:
     nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/ed714e635b330bb42666ecdd0c0b4f30224ded15b0b0052d6bc2b92832f2cf17d1c1141359453f96f0a84f8fbf4c405a74df187f559163b8f31131b2535455aa
+  checksum: 10c0/0a12c1e74b456c57122e81f684e02fd98ff4d57526f794d10c996df1147158808f5ae373ac82b988c8de6cbbaa82dbd7b13803b14f5dd3cf7cc6a42ccad5c9f2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- `postcss` was deduping to `8.5.15` via vite's transitive `postcss@^8.5.15` request — vulnerable to [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) and [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) (`sourceMappingURL` path traversal / arbitrary `.map` file disclosure). Bumped the direct dependency to `^8.5.25` and added a scoped `resolutions` entry so the transitive copy dedupes to the patched version.
- `brace-expansion` was deduping to `5.0.6` via `minimatch@10.2.5`'s `brace-expansion@^5.0.5` request — vulnerable to [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp), [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), and [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (DoS via unbounded expansion). Added a scoped resolution forcing that range to `^5.0.9`, leaving the unrelated `brace-expansion@^1.1.7` (v1.x) line used by `minimatch@3.1.5` untouched.

Jira: [PHR-3351](https://icanbwell.atlassian.net/browse/PHR-3351)

## Test plan
- [x] `yarn install` — lockfile regenerated, postcss deduped to a single `8.5.25` entry
- [x] `yarn npm audit --recursive` — no longer reports either advisory
- [x] `yarn build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PHR-3351]: https://icanbwell.atlassian.net/browse/PHR-3351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ