### PR TITLE
PHR-3356 Stream FHIR responses progressively instead of buffering the full body

### DIFF
--- a/docs/superpowers/plans/2026-08-06-fhir-streaming-implementation.md
+++ b/docs/superpowers/plans/2026-08-06-fhir-streaming-implementation.md
@@ -1,0 +1,1146 @@
+# Streaming FHIR Responses Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let every page that calls the FHIR server display results as they arrive over the wire (instead of after the full response buffers) and resist idle-timeouts, using one shared streaming HTTP client instead of duplicated per-page code.
+
+**Architecture:** Generalize the API Console's existing `fetch()` + `ReadableStream` reader pattern into a new `BaseApi.streamRequest()` method. `getData()`, `request()`, and `downloadFile()` become thin wrappers over it (axios is removed from `BaseApi`/`FhirApi`/`AdminApi` entirely). Pages that want visible progress pass an `onProgress` callback into their existing calls (Tier A); the search/`IndexPage` resource list additionally gets true incremental resource-by-resource rendering via a streaming JSON parser (Tier B).
+
+**Tech Stack:** React 19, TypeScript, Vite, MUI 9. New dependency: `@streamparser/json` (browser-native streaming JSON parser, verified on npm at v0.0.23).
+
+**Source spec:** `docs/superpowers/specs/2026-08-06-fhir-streaming-design.md`
+
+## Global Constraints
+
+- No page may implement its own `fetch`/reader loop. All streaming logic lives in `BaseApi.streamRequest()`; `FhirApi`, `AdminApi`, and every page consume it through `getData()`/`request()`/`downloadFile()`/`getBundleAsync()`.
+- `getData()`, `request()`, and `downloadFile()` keep their current return shape and behavior for existing callers that don't pass streaming options — this is a non-breaking internal refactor by default.
+- `axios` is removed from `BaseApi` (and therefore `FhirApi`/`AdminApi`). It remains a dependency only for the unrelated OIDC/auth services (`CognitoAuthService.ts`, `OktaAuthService.ts`, `ClientCredentialsAuthService.ts`, `BwellAppAuthService.ts`, `WellKnownConfigurationService.ts`, `Auth.tsx`) — do not touch those files.
+- **No automated test framework in this plan.** This repo has zero test infrastructure today (no runner, no config, no test files); Vitest is being added in a separate PR. Every task below ends with a **manual verification** step (dev server commands, browser actions, expected observations) instead of an automated test cycle. Write new logic as small, pure, injectable functions so it's trivial to cover once Vitest lands.
+- Run `yarn lint` before every commit — the repo's pre-commit hook enforces this and will block the commit otherwise.
+- Dev server: `yarn dev`, served at `http://localhost:5051`.
+
+## Deviations from the source spec (found during planning)
+
+1. **Tier A scope narrowed for admin pages.** The spec listed "all AdminApi-backed admin pages" under Tier A (progress indicator). Inspecting every `AdminApi` method (`src/api/adminApi.ts`) and its callers shows they're all small request/response operations (person-match lookups, cache-key lists, search-log results, single status resources) — none return a response large enough for a progress indicator to be meaningful. Phase 1 already gives these pages the transport-level streaming/timeout-resilience benefit for free (via `request()`), with no page-level changes needed. This plan does not add Tier A progress UI to any admin page. If a specific admin operation later turns out to return large payloads, add a task then.
+2. **Tier B error handling is coarser than the spec described.** The spec said "a malformed individual entry is logged and skipped... does not abort the stream." Verified against the actual `@streamparser/json` library (see Task 13): its tokenizer is stream-fatal — any malformed token anywhere aborts the *entire* incremental parse, not just one entry, because it's one continuous tokenizer over the whole byte stream. Task 14 implements the achievable equivalent: on a parser error, incremental updates stop (whatever resources already rendered stay on screen) and the page falls back to the existing end-of-stream full `JSON.parse` as the source of truth — so the user never ends up with missing data, they just lose the "watch it populate live" effect for that one malformed response.
+
+---
+
+## Phase 1: Shared streaming client foundation
+
+### Task 1: Add `BaseApi.streamRequest()`
+
+**Files:**
+- Modify: `src/api/baseApi.ts`
+
+**Interfaces:**
+- Produces: `StreamRequestParams` (`method: HttpMethod`, `urlString: string`, `params?: Record<string, string>`, `data?: any`, `headers?: Record<string, string>`, `signal?: AbortSignal`, `responseMode?: 'text' | 'binary'` default `'text'`, `onHeaders?: (status: number, headers: Record<string,string>) => void`, `onChunk?: (chunk: Uint8Array) => void`, `onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void`) and `StreamRequestResult` (`status: number | undefined`, `headers: Record<string,string>`, `bytes: Uint8Array`, `text: string`, `incomplete: boolean`) — every later task in this plan consumes these exact shapes.
+
+- [ ] **Step 1: Add the new types and `streamRequest()` method to `BaseApi`**
+
+Add near the top of `src/api/baseApi.ts`, alongside the existing `GetDataParams`/`RequestParams` interfaces:
+
+```ts
+export interface StreamRequestParams {
+    method: HttpMethod;
+    urlString: string;
+    params?: Record<string, string>;
+    data?: any;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+    responseMode?: 'text' | 'binary';
+    onHeaders?: (status: number, headers: Record<string, string>) => void;
+    onChunk?: (chunk: Uint8Array) => void;
+    onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void;
+}
+
+export interface StreamRequestResult {
+    status: number | undefined;
+    headers: Record<string, string>;
+    bytes: Uint8Array;
+    text: string;
+    incomplete: boolean;
+}
+```
+
+Add this import at the top (it's already imported for `HttpMethod`, so this is likely already present — verify, don't duplicate):
+
+```ts
+import { HttpMethod, TRequestInfo } from '../context/LastRequestContext';
+```
+
+Add the method inside the `BaseApi` class (place it above `getData`, since `getData`/`request`/`downloadFile` will call it in later tasks):
+
+```ts
+async streamRequest({
+    method,
+    urlString,
+    params,
+    data,
+    headers,
+    signal,
+    responseMode = 'text',
+    onHeaders,
+    onChunk,
+    onProgress,
+}: StreamRequestParams): Promise<StreamRequestResult> {
+    let path = urlString;
+    if (path.startsWith(window.location.origin)) {
+        path = path.slice(window.location.origin.length);
+    }
+    const url = new URL(path, this.getBaseUrl());
+    if (params) {
+        Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
+    }
+
+    // The session's bearer token must never leave the configured base URL. A scheme-relative
+    // or absolute path can resolve to a different origin via `new URL()`, so refuse before any
+    // fetch happens rather than trusting every caller to have validated its own input. This
+    // check used to live only in FhirApi.sendRequest (the one caller that took a free-form path
+    // from user input); moving it here means every BaseApi-derived call gets the guarantee.
+    if (url.origin !== new URL(this.getBaseUrl()).origin) {
+        return {
+            status: undefined,
+            headers: {},
+            bytes: new Uint8Array(0),
+            text: JSON.stringify({ error: 'Request path must stay on the configured FHIR server' }),
+            incomplete: false,
+        };
+    }
+
+    this.onRequest?.({ method, url: url.pathname + url.search });
+
+    const requestHeaders = this.buildHeaders({
+        'Content-Type': 'application/fhir+json',
+        ...headers,
+    });
+
+    let response: Response;
+    try {
+        response = await fetch(url.toString(), {
+            method,
+            headers: requestHeaders,
+            body: data !== undefined && data !== null ? JSON.stringify(data) : undefined,
+            signal,
+        });
+    } catch (err: any) {
+        if (err?.name === 'AbortError') {
+            throw err;
+        }
+        return { status: undefined, headers: {}, bytes: new Uint8Array(0), text: '', incomplete: true };
+    }
+
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+        responseHeaders[key] = value;
+    });
+
+    // Surface status/headers as soon as fetch() resolves — before the body streaming loop
+    // below starts — so callers can populate UI without waiting for the whole body.
+    onHeaders?.(response.status, responseHeaders);
+    await this.handleUnauthorized(response.status);
+
+    const totalBytes = responseHeaders['content-length']
+        ? parseInt(responseHeaders['content-length'], 10)
+        : undefined;
+
+    const receivedChunks: Uint8Array[] = [];
+    let receivedBytes = 0;
+    const decoder = new TextDecoder();
+    let text = '';
+
+    const finalize = (incomplete: boolean): StreamRequestResult => {
+        const bytes = new Uint8Array(receivedBytes);
+        let offset = 0;
+        for (const chunk of receivedChunks) {
+            bytes.set(chunk, offset);
+            offset += chunk.length;
+        }
+        return { status: response.status, headers: responseHeaders, bytes, text, incomplete };
+    };
+
+    try {
+        if (response.body) {
+            const reader = response.body.getReader();
+            let done = false;
+            while (!done) {
+                const result = await reader.read();
+                done = result.done;
+                if (result.value) {
+                    receivedChunks.push(result.value);
+                    receivedBytes += result.value.length;
+                    if (responseMode === 'text') {
+                        text += decoder.decode(result.value, { stream: true });
+                    }
+                    onChunk?.(result.value);
+                    onProgress?.(receivedBytes, totalBytes);
+                }
+            }
+        } else if (responseMode === 'text') {
+            text = await response.text();
+            onChunk?.(new TextEncoder().encode(text));
+            onProgress?.(text.length, totalBytes);
+        }
+    } catch (err: any) {
+        if (err?.name === 'AbortError') {
+            throw err;
+        }
+        // A mid-stream drop rejects here. Headers were already surfaced via onHeaders and
+        // whatever bytes arrived via onChunk, so resolve with the partial data instead of
+        // throwing — callers decide how to degrade rather than losing everything.
+        return finalize(true);
+    }
+
+    return finalize(false);
+}
+```
+
+- [ ] **Step 2: Manual verification — the method compiles and doesn't break the build**
+
+Run: `yarn tsc --noEmit`
+Expected: no new TypeScript errors introduced by this change (the app doesn't call `streamRequest` yet, so this is purely a compile check).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/baseApi.ts
+git commit -m "Add BaseApi.streamRequest() as the shared fetch+ReadableStream client"
+```
+
+---
+
+### Task 2: Refactor `BaseApi.getData()` onto `streamRequest()`
+
+**Files:**
+- Modify: `src/api/baseApi.ts:107-121` (current `getData` implementation)
+
+**Interfaces:**
+- Consumes: `streamRequest()` from Task 1.
+- Produces: `getData(params: GetDataParams, options?: { onChunk?: (chunk: Uint8Array) => void; onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void }): Promise<{ status: number | undefined; json: any; incomplete: boolean }>` — Task 8, 9, and 12 call this with the new second `options` argument.
+
+- [ ] **Step 1: Replace the axios-based `getData()` body**
+
+Replace the existing `getData` method:
+
+```ts
+async getData(
+    { urlString, params }: GetDataParams,
+    options?: {
+        onChunk?: (chunk: Uint8Array) => void;
+        onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void;
+    }
+): Promise<{ status: number | undefined; json: any; incomplete: boolean }> {
+    const { status, text, incomplete } = await this.streamRequest({
+        method: 'GET',
+        urlString,
+        params,
+        onChunk: options?.onChunk,
+        onProgress: options?.onProgress,
+    });
+    let json: any;
+    try {
+        json = text ? JSON.parse(text) : undefined;
+    } catch {
+        json = undefined;
+    }
+    return { status, json, incomplete };
+}
+```
+
+Note this drops the old manual `try/catch` around an axios call and the separate `err.response?.status` handling — `streamRequest()` already resolves (rather than throws) on HTTP error statuses and already calls `handleUnauthorized()` internally, so that behavior is preserved without the try/catch.
+
+- [ ] **Step 2: Manual verification — existing pages still load resources correctly**
+
+Run: `yarn dev`, then in a browser:
+1. Navigate to `http://localhost:5051/4_0_0/Patient/_search?_count=5` (or any resourceType your dev FHIR server has data for) and confirm the resource list still renders (this page — `IndexPage`/`SearchPage` — calls `getData()` transitively via `getBundleAsync()`).
+2. Open DevTools → Network tab, find the request, confirm the response still shows the same JSON body/status as before this change.
+3. Navigate to a URL for a resource type that doesn't exist or an expired-session scenario if you can trigger one, and confirm the existing error/"Login Expired" UI still appears (exercises the non-2xx path).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/baseApi.ts
+git commit -m "Refactor BaseApi.getData() onto streamRequest(), drop axios for GET reads"
+```
+
+---
+
+### Task 3: Refactor `BaseApi.request()` onto `streamRequest()`
+
+**Files:**
+- Modify: `src/api/baseApi.ts:127-144` (current `request` implementation)
+
+**Interfaces:**
+- Consumes: `streamRequest()` from Task 1.
+- Produces: `request(params: RequestParams, options?: { onChunk?: (chunk: Uint8Array) => void; onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void }): Promise<{ status: number | undefined; json: any; incomplete: boolean }>`.
+
+- [ ] **Step 1: Replace the axios-based `request()` body**
+
+```ts
+async request(
+    { urlString, params, method, data }: RequestParams,
+    options?: {
+        onChunk?: (chunk: Uint8Array) => void;
+        onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void;
+    }
+): Promise<{ status: number | undefined; json: any; incomplete: boolean }> {
+    const { status, text, incomplete } = await this.streamRequest({
+        method,
+        urlString,
+        params,
+        data,
+        onChunk: options?.onChunk,
+        onProgress: options?.onProgress,
+    });
+    let json: any;
+    try {
+        json = text ? JSON.parse(text) : undefined;
+    } catch {
+        json = undefined;
+    }
+    return { status, json, incomplete };
+}
+```
+
+Note this fixes the pre-existing documented gap in the old `request()` (the comment above the old implementation noted `onRequest` was never fired with the fully-resolved URL) for free — `streamRequest()` calls `this.onRequest?.(...)` after resolving the final URL.
+
+- [ ] **Step 2: Manual verification — admin operations still work**
+
+Run: `yarn dev`, then in a browser (adjust IDs to real data in your dev environment):
+1. Navigate to `http://localhost:5051/admin/personMatch` and run a person-match lookup; confirm results render.
+2. Navigate to `http://localhost:5051/admin/searchLog` and run a search-log lookup; confirm results render.
+3. Check DevTools Network tab for both requests — confirm status/response body look correct and no console errors appear.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/baseApi.ts
+git commit -m "Refactor BaseApi.request() onto streamRequest(), drop axios for writes/admin calls"
+```
+
+---
+
+### Task 4: Refactor `BaseApi.downloadFile()` onto `streamRequest()` (binary-safe)
+
+**Files:**
+- Modify: `src/api/baseApi.ts:146-162` (current `downloadFile` implementation)
+
+**Interfaces:**
+- Consumes: `streamRequest()` from Task 1, with `responseMode: 'binary'`.
+- Produces: `downloadFile(url: string, options?: { onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void }): Promise<{ status: number; data: Blob; headers: Record<string, string> }>` — throws an `Error` (with a `.status` property) for non-2xx responses, matching axios's default reject-on-error-status behavior that `SpreadsheetViewer.tsx` and `FileDownload.tsx` currently rely on in their `catch` blocks.
+
+- [ ] **Step 1: Replace the axios-based `downloadFile()` body**
+
+```ts
+async downloadFile(
+    url: string,
+    options?: { onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void }
+): Promise<{ status: number; data: Blob; headers: Record<string, string> }> {
+    const { status, bytes, headers } = await this.streamRequest({
+        method: 'GET',
+        urlString: url,
+        responseMode: 'binary',
+        onProgress: options?.onProgress,
+    });
+    if (!status || status < 200 || status >= 300) {
+        throw Object.assign(new Error(`Request failed with status ${status}`), { status });
+    }
+    const contentType = headers['content-type'] || 'application/octet-stream';
+    return { status, data: new Blob([bytes], { type: contentType }), headers };
+}
+```
+
+(401 handling already happened inside `streamRequest()` via `handleUnauthorized()` before this method sees the result, so the old `if (err.response?.status === 401 ...) logout()` branch in the removed catch block is preserved.)
+
+- [ ] **Step 2: Manual verification — spreadsheet/file download still works**
+
+Run: `yarn dev`, then in a browser:
+1. Navigate to a `$everything` or search result page, click "Open Search Results as Spreadsheet" (routes to `ExcelViewerPage`/`SpreadsheetViewer`), confirm the grid still populates.
+2. Click the download icon (`FileDownload`) on that page, confirm a file actually downloads with the correct filename and opens correctly (CSV/XLSX).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/baseApi.ts
+git commit -m "Refactor BaseApi.downloadFile() onto streamRequest(), binary-safe chunk assembly"
+```
+
+---
+
+### Task 5: Remove axios from `BaseApi`
+
+**Files:**
+- Modify: `src/api/baseApi.ts`
+
+**Interfaces:**
+- Consumes: nothing new — this is cleanup now that Tasks 2–4 no longer use `this.axiosInstance`.
+- Produces: `BaseApi` has no axios dependency; `buildHeaders()` remains as a plain method used directly by `streamRequest()`.
+
+- [ ] **Step 1: Delete the axios instance, interceptor, and imports**
+
+In `src/api/baseApi.ts`:
+- Remove the imports: `import axios, { AxiosInstance } from 'axios';` and `import { InternalAxiosRequestConfig } from 'axios';`.
+- Remove the `private readonly axiosInstance: AxiosInstance;` field.
+- Remove the two lines in the constructor: `this.axiosInstance = axios.create();` and `this.axiosInstance.interceptors.request.use(this.requestInterceptor.bind(this));`.
+- Remove the `requestInterceptor(req: InternalAxiosRequestConfig<any>): InternalAxiosRequestConfig<any> { ... }` method entirely (no longer called by anything).
+- Leave `buildHeaders()` and `handleUnauthorized()` exactly as they are — `streamRequest()` already calls `buildHeaders()` directly.
+
+- [ ] **Step 2: Manual verification — build still succeeds with axios removed from this file**
+
+Run: `yarn tsc --noEmit`
+Expected: no errors (confirms nothing else in `baseApi.ts` still references axios types).
+
+Run: `yarn lint`
+Expected: no new errors (the unused-import rule would catch a leftover axios import if Step 1 was incomplete).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/baseApi.ts
+git commit -m "Remove axios from BaseApi now that all methods use streamRequest()"
+```
+
+---
+
+### Task 6: `FhirApi.sendRequest()` delegates to `BaseApi.streamRequest()`
+
+**Files:**
+- Modify: `src/api/fhirApi.ts:122-250` (current `sendRequest` implementation)
+
+**Interfaces:**
+- Consumes: `BaseApi.streamRequest()` from Task 1.
+- Produces: `sendRequest(...)` keeps its exact existing external signature and return shape (`{ status, json, headers, rawText, incomplete? }`) — `src/pages/APIConsolePage.tsx` requires zero changes.
+
+- [ ] **Step 1: Replace the duplicated fetch/reader loop with a call to `streamRequest()`**
+
+Replace the body of `sendRequest` (everything after the parameter destructuring) with:
+
+```ts
+async sendRequest({
+    method,
+    urlPath,
+    data,
+    headers,
+    onChunk,
+    onHeaders,
+    signal,
+}: {
+    method: HttpMethod;
+    urlPath: string;
+    data?: object;
+    headers?: Record<string, string>;
+    onChunk?: (text: string) => void;
+    onHeaders?: (status: number, headers: Record<string, string>) => void;
+    signal?: AbortSignal;
+}): Promise<{
+    status: number | undefined;
+    json: any;
+    headers: Record<string, string>;
+    rawText: string;
+    incomplete?: boolean;
+}> {
+    // APIConsolePage's onChunk expects decoded text, but streamRequest hands back raw
+    // Uint8Array chunks (so binary downloads elsewhere aren't forced through a decoder). Keep
+    // one TextDecoder alive across the whole request — decoding each chunk independently would
+    // corrupt any multi-byte UTF-8 character split across a chunk boundary.
+    const decoder = new TextDecoder();
+    const result = await this.streamRequest({
+        method,
+        urlString: urlPath,
+        data,
+        headers,
+        signal,
+        onHeaders,
+        onChunk: onChunk ? (chunk) => onChunk(decoder.decode(chunk, { stream: true })) : undefined,
+    });
+
+    let json: any;
+    try {
+        json = result.text ? JSON.parse(result.text) : undefined;
+    } catch {
+        json = undefined;
+    }
+
+    return {
+        status: result.status,
+        json,
+        headers: result.headers,
+        rawText: result.text,
+        incomplete: result.incomplete,
+    };
+}
+```
+
+This removes the duplicated origin-lock check, fetch call, and manual reader loop (~70 lines) that used to live directly in `FhirApi` — they're now provided once by `BaseApi.streamRequest()`.
+
+- [ ] **Step 2: Manual verification — API Console streaming behavior is unchanged**
+
+Run: `yarn dev`, navigate to `http://localhost:5051/api-console`:
+1. Send a `GET` request to `/4_0_0/Patient?_count=20` (or any endpoint returning a reasonably sized body). Confirm the "Body (Receiving…)" tab still shows text accumulating before the response finishes, and the final parsed/collapsible JSON view still appears once complete.
+2. Confirm the status `Chip` and Headers tab still populate immediately (before the body finishes) — this proves `onHeaders` still fires early.
+3. Send a request, then immediately navigate away from `/api-console` mid-stream (or send a second request before the first finishes) — confirm no console errors from the aborted request and no stale state overwrite (tests the existing `AbortController` cancellation path still works through the new code).
+4. In the "Request Path" field, type an absolute URL to a different origin (e.g. `https://example.com`) and send — confirm you get back the `"Request path must stay on the configured FHIR server"` error, proving the origin-lock check still works from its new home in `streamRequest()`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/fhirApi.ts
+git commit -m "FhirApi.sendRequest() delegates to BaseApi.streamRequest(), removing duplicate reader loop"
+```
+
+---
+
+## Phase 2: Tier A — visible progress for large-response pages
+
+### Task 7: Add `useStreamProgress` hook and `StreamProgressIndicator` component
+
+**Files:**
+- Create: `src/hooks/useStreamProgress.ts`
+- Create: `src/components/StreamProgressIndicator.tsx`
+
+**Interfaces:**
+- Produces: `useStreamProgress(): { progress: StreamProgressState; start: () => void; onProgress: (bytesReceived: number, totalBytes: number | undefined) => void; finish: () => void }` and `StreamProgressState = { bytesReceived: number; totalBytes: number | undefined; isStreaming: boolean }`. `<StreamProgressIndicator progress={StreamProgressState} />`. Tasks 8–10 consume both.
+
+- [ ] **Step 1: Write the hook**
+
+`src/hooks/useStreamProgress.ts`:
+
+```ts
+import { useCallback, useState } from 'react';
+
+export interface StreamProgressState {
+    bytesReceived: number;
+    totalBytes: number | undefined;
+    isStreaming: boolean;
+}
+
+const INITIAL_STATE: StreamProgressState = {
+    bytesReceived: 0,
+    totalBytes: undefined,
+    isStreaming: false,
+};
+
+export function useStreamProgress() {
+    const [progress, setProgress] = useState<StreamProgressState>(INITIAL_STATE);
+
+    const start = useCallback(() => {
+        setProgress({ bytesReceived: 0, totalBytes: undefined, isStreaming: true });
+    }, []);
+
+    const onProgress = useCallback((bytesReceived: number, totalBytes: number | undefined) => {
+        setProgress((prev) => ({ ...prev, bytesReceived, totalBytes, isStreaming: true }));
+    }, []);
+
+    const finish = useCallback(() => {
+        setProgress((prev) => ({ ...prev, isStreaming: false }));
+    }, []);
+
+    return { progress, start, onProgress, finish };
+}
+```
+
+- [ ] **Step 2: Write the indicator component**
+
+`src/components/StreamProgressIndicator.tsx`:
+
+```tsx
+import React from 'react';
+import { Box, LinearProgress, Typography } from '@mui/material';
+import { StreamProgressState } from '../hooks/useStreamProgress';
+
+function formatBytes(bytes: number): string {
+    if (bytes < 1024) {
+        return `${bytes} B`;
+    }
+    if (bytes < 1024 * 1024) {
+        return `${(bytes / 1024).toFixed(1)} KB`;
+    }
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+interface StreamProgressIndicatorProps {
+    progress: StreamProgressState;
+}
+
+const StreamProgressIndicator: React.FC<StreamProgressIndicatorProps> = ({ progress }) => {
+    if (!progress.isStreaming) {
+        return null;
+    }
+    const percent = progress.totalBytes
+        ? Math.min(100, Math.round((progress.bytesReceived / progress.totalBytes) * 100))
+        : undefined;
+    return (
+        <Box sx={{ width: '100%', my: 2 }}>
+            <LinearProgress variant={percent !== undefined ? 'determinate' : 'indeterminate'} value={percent} />
+            <Typography variant="caption" sx={{ mt: 0.5, display: 'block' }}>
+                {percent !== undefined
+                    ? `Loading… ${formatBytes(progress.bytesReceived)} of ${formatBytes(progress.totalBytes as number)} (${percent}%)`
+                    : `Loading… ${formatBytes(progress.bytesReceived)} received`}
+            </Typography>
+        </Box>
+    );
+};
+
+export default StreamProgressIndicator;
+```
+
+- [ ] **Step 3: Manual verification — compiles cleanly**
+
+Run: `yarn tsc --noEmit && yarn lint`
+Expected: no errors (nothing consumes these yet, so this just checks the new files are well-formed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useStreamProgress.ts src/components/StreamProgressIndicator.tsx
+git commit -m "Add shared useStreamProgress hook and StreamProgressIndicator component"
+```
+
+---
+
+### Task 8: Wire progress into `CompositionSummaryPage.tsx`
+
+**Files:**
+- Modify: `src/pages/CompositionSummaryPage.tsx`
+
+**Interfaces:**
+- Consumes: `useStreamProgress()` and `<StreamProgressIndicator>` from Task 7; `baseApi.getData(params, options)` from Task 2.
+
+- [ ] **Step 1: Wire the hook into the fetch effect**
+
+Add the import:
+
+```tsx
+import { useStreamProgress } from '../hooks/useStreamProgress';
+import StreamProgressIndicator from '../components/StreamProgressIndicator';
+```
+
+Inside the component, add:
+
+```tsx
+const { progress, start, onProgress, finish } = useStreamProgress();
+const [isIncomplete, setIsIncomplete] = useState<boolean>(false);
+```
+
+Update the `fetchResource` function inside the existing `useEffect`:
+
+```tsx
+const fetchResource = async () => {
+    setIsLoading(true);
+    setErrorMessage(null);
+    setIsIncomplete(false);
+    start();
+    try {
+        const response = await baseApi.getData({ urlString: relativeUrl }, { onProgress });
+        const json = response.json;
+        setRawResponse(json);
+        setIsIncomplete(response.incomplete);
+        if (json?.resourceType === 'Composition') {
+            setResource(json);
+        } else {
+            setErrorMessage('The requested resource is not a Composition');
+        }
+    } catch (error) {
+        console.error('Error fetching Composition resource:', error);
+        setErrorMessage('Failed to load the Composition resource');
+    } finally {
+        setIsLoading(false);
+        finish();
+    }
+};
+```
+
+Update the render section: replace the `{isLoading && (...CircularProgress...)}` block with:
+
+```tsx
+{isLoading && (
+    <Box sx={{ my: 4 }}>
+        <StreamProgressIndicator progress={progress} />
+    </Box>
+)}
+{!isLoading && isIncomplete && (
+    <Alert severity="warning" sx={{ mb: 2 }}>
+        Connection interrupted — showing partial results.
+    </Alert>
+)}
+```
+
+(You can leave the `CircularProgress` import if it's still used elsewhere in the file; if this was its only use, remove the now-unused `CircularProgress` import to keep lint clean.)
+
+- [ ] **Step 2: Manual verification**
+
+Run: `yarn dev`, navigate to `http://localhost:5051/composition-summary/4_0_0/Composition/<a-real-id>`:
+1. Confirm the page still renders the Composition summary correctly.
+2. Open DevTools → Network → throttle to "Slow 3G" and reload — confirm you now see a progress bar/byte counter (indeterminate is fine if the server doesn't send `Content-Length`) instead of a static spinner while it loads.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/CompositionSummaryPage.tsx
+git commit -m "Show streaming progress indicator on CompositionSummaryPage"
+```
+
+---
+
+### Task 9: Wire progress into `IPSViewer.tsx`
+
+**Files:**
+- Modify: `src/components/IPSViewer.tsx`
+
+**Interfaces:**
+- Consumes: `useStreamProgress()` and `<StreamProgressIndicator>` from Task 7; `baseApi.getData(params, options)` from Task 2.
+
+- [ ] **Step 1: Wire the hook into `fetchBundle`**
+
+Add the imports (alongside the existing ones):
+
+```tsx
+import { useStreamProgress } from '../hooks/useStreamProgress';
+import StreamProgressIndicator from './StreamProgressIndicator';
+```
+
+Inside the component, add:
+
+```tsx
+const { progress, start, onProgress, finish } = useStreamProgress();
+const [isIncomplete, setIsIncomplete] = useState<boolean>(false);
+```
+
+Update `fetchBundle`:
+
+```tsx
+const fetchBundle = async () => {
+    setIsLoading(true);
+    setErrorMessage(null);
+    setIsIncomplete(false);
+    start();
+
+    try {
+        const response = await baseApi.getData({ urlString: relativeUrl }, { onProgress });
+        const bundleData: Bundle = response.json;
+        setRawResponse(bundleData);
+        setIsIncomplete(response.incomplete);
+        // ... rest of the existing body unchanged (compositionEntry extraction, etc.)
+    } catch (error) {
+        console.error('Error fetching IPS bundle:', error);
+        setErrorMessage('Failed to load the International Patient Summary');
+    } finally {
+        setIsLoading(false);
+        finish();
+    }
+};
+```
+
+Update the loading render branch — replace:
+
+```tsx
+if (isLoading) {
+    return (
+        <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
+            <CircularProgress />
+        </Box>
+    );
+}
+```
+
+with:
+
+```tsx
+if (isLoading) {
+    return (
+        <Box sx={{ my: 4 }}>
+            <StreamProgressIndicator progress={progress} />
+        </Box>
+    );
+}
+```
+
+Add an incomplete-response notice right after the existing `if (errorMessage) { ... }` block, before the main `return`:
+
+```tsx
+{isIncomplete && (
+    <Alert severity="warning" sx={{ mb: 2 }}>
+        Connection interrupted — showing partial results.
+    </Alert>
+)}
+```
+
+(Since the successful-render path returns a single top-level `<Box>`, add this as its first child rather than a separate top-level statement — adjust to fit the existing JSX structure at `IPSViewer.tsx:331` onward.)
+
+- [ ] **Step 2: Manual verification**
+
+Run: `yarn dev`, navigate to `http://localhost:5051/ips/4_0_0/Patient/<a-real-patient-id>/$summary`:
+1. Confirm the IPS summary still renders (narrative + sections + bundle resources list) exactly as before.
+2. Throttle network to "Slow 3G" and reload — confirm the progress indicator shows while the (typically large) `$summary` bundle downloads.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/IPSViewer.tsx
+git commit -m "Show streaming progress indicator on IPSViewer"
+```
+
+---
+
+### Task 10: Wire byte-progress into `SpreadsheetViewer.tsx` and `FileDownload.tsx` downloads
+
+**Files:**
+- Modify: `src/components/SpreadsheetViewer.tsx`
+- Modify: `src/components/FileDownload.tsx`
+
+**Interfaces:**
+- Consumes: `useStreamProgress()` / `<StreamProgressIndicator>` from Task 7; `baseApi.downloadFile(url, options)` from Task 4.
+
+- [ ] **Step 1: `SpreadsheetViewer.tsx` — add progress to the download**
+
+Add the imports:
+
+```tsx
+import { useStreamProgress } from '../hooks/useStreamProgress';
+import StreamProgressIndicator from './StreamProgressIndicator';
+```
+
+Inside the component, add:
+
+```tsx
+const { progress, start, onProgress, finish } = useStreamProgress();
+```
+
+In `fetchSpreadsheetData`, wrap the download call:
+
+```tsx
+setIsLoading(true);
+setErrorMessage(null);
+start();
+
+const response = await baseApi.downloadFile(downloadUri.toString(), { onProgress });
+```
+
+and add `finish();` alongside the existing `setIsLoading(false);` calls in both the success and `catch` paths.
+
+Update the loading-state render block:
+
+```tsx
+if (isLoading) {
+    return (
+        <Box
+            sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', height: '100%' }}
+        >
+            <StreamProgressIndicator progress={progress} />
+            <Typography variant="body2" sx={{ mt: 2 }}>
+                Loading spreadsheet...
+            </Typography>
+        </Box>
+    );
+}
+```
+
+- [ ] **Step 2: `FileDownload.tsx` — add progress during download**
+
+Add the imports:
+
+```tsx
+import { useStreamProgress } from '../hooks/useStreamProgress';
+import StreamProgressIndicator from './StreamProgressIndicator';
+```
+
+Inside the component, add:
+
+```tsx
+const { progress, start, onProgress, finish } = useStreamProgress();
+```
+
+In `downloadFile`, wrap the call:
+
+```tsx
+setIsLoading(true);
+setErrorMessage(null);
+start();
+try {
+    const response = await baseApi.downloadFile(downloadUri.toString(), { onProgress });
+    // ... existing body unchanged ...
+} catch (error1: unknown) {
+    // ... existing body unchanged ...
+} finally {
+    finish();
+}
+```
+
+(Add a `finally` block if one doesn't already wrap the existing `setIsLoading(false)` calls — consolidate the two existing `setIsLoading(false)` calls into a single `finally` while you're there, since both branches already only need it once.)
+
+Add the indicator to the render output, right before the existing `<Tooltip>` button:
+
+```tsx
+{isLoading && <StreamProgressIndicator progress={progress} />}
+```
+
+- [ ] **Step 3: Manual verification**
+
+Run: `yarn dev`, navigate to a search result page, open it as a spreadsheet (`/excel/...`):
+1. Throttle network to "Slow 3G", reload — confirm `SpreadsheetViewer` shows byte-progress while downloading.
+2. Click the download icon (`FileDownload`) — confirm a progress indicator briefly appears and the file still downloads correctly with the right filename.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/SpreadsheetViewer.tsx src/components/FileDownload.tsx
+git commit -m "Show byte-progress during spreadsheet/file downloads"
+```
+
+---
+
+## Phase 3: Tier B — incremental resource rendering on the search/IndexPage list
+
+### Task 11: Add the `@streamparser/json` dependency
+
+**Files:**
+- Modify: `package.json`, `yarn.lock` (via the command below)
+
+- [ ] **Step 1: Install**
+
+Run: `yarn add @streamparser/json`
+Expected: `package.json` gains `"@streamparser/json": "^0.0.23"` (or newer patch) under `dependencies`, `yarn.lock` updates accordingly.
+
+- [ ] **Step 2: Manual verification**
+
+Run: `yarn lint`
+Expected: passes (no code uses the new package yet, so this just confirms the install didn't break anything).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json yarn.lock
+git commit -m "Add @streamparser/json dependency for incremental Bundle parsing"
+```
+
+---
+
+### Task 12: Let `FhirApi.getBundleAsync()` forward chunk callbacks
+
+**Files:**
+- Modify: `src/api/fhirApi.ts:38-51` (current `getBundleAsync` implementation)
+
+**Interfaces:**
+- Consumes: `getData()`'s new `options` parameter from Task 2.
+- Produces: `getBundleAsync(params: GetBundleAsyncParams, options?: { onChunk?: (chunk: Uint8Array) => void }): Promise<{ status: number; json: any; incomplete: boolean }>` — Task 14 calls this with `onChunk` set.
+
+- [ ] **Step 1: Add and forward the optional `onChunk` parameter**
+
+```ts
+async getBundleAsync(
+    { resourceType, id, queryString, queryParameters, operation }: GetBundleAsyncParams,
+    options?: { onChunk?: (chunk: Uint8Array) => void }
+): Promise<{ status: number; json: any; incomplete: boolean }> {
+    const url = this.getUrl({
+        resourceType,
+        id,
+        queryString,
+        queryParameters,
+        operation,
+    });
+    return await this.getData({ urlString: url.toString() }, options);
+}
+```
+
+- [ ] **Step 2: Manual verification**
+
+Run: `yarn tsc --noEmit`
+Expected: no errors (`IndexPage.tsx`'s existing call `fhirApi.getBundleAsync({...})` still compiles since `options` is optional).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/fhirApi.ts
+git commit -m "Let FhirApi.getBundleAsync() forward an optional onChunk callback"
+```
+
+---
+
+### Task 13: Build the incremental Bundle-entry parser utility
+
+**Files:**
+- Create: `src/utils/incrementalBundleParser.ts`
+
+**Interfaces:**
+- Produces: `createBundleEntryParser(onEntry: (resource: any) => void, onError: (err: Error) => void): { write: (chunk: Uint8Array) => void; finish: () => void }` — Task 14 consumes this exactly.
+
+- [ ] **Step 1: Write the parser wrapper**
+
+`src/utils/incrementalBundleParser.ts`:
+
+```ts
+import { JSONParser } from '@streamparser/json';
+
+/**
+ * Wraps @streamparser/json to emit each Bundle.entry[].resource as it completes, instead of
+ * waiting for the whole Bundle JSON object to finish downloading.
+ *
+ * The underlying tokenizer is stream-fatal: a single malformed token anywhere aborts the whole
+ * parse (it's one continuous tokenizer over the byte stream, not a per-entry recovery
+ * mechanism), so onError should be treated as "stop calling write(), fall back to the
+ * caller's own full JSON.parse of the complete response" rather than "skip one bad entry."
+ *
+ * With no `separator` option, the parser auto-ends after the single top-level Bundle object
+ * completes — calling finish() after that would throw, so finish() checks isEnded first.
+ */
+export function createBundleEntryParser(
+    onEntry: (resource: any) => void,
+    onError: (err: Error) => void
+): { write: (chunk: Uint8Array) => void; finish: () => void } {
+    const parser = new JSONParser({ paths: ['$.entry.*.resource'], keepStack: false });
+    parser.onValue = ({ value }) => onEntry(value);
+    parser.onError = onError;
+
+    return {
+        write: (chunk: Uint8Array) => {
+            if (!parser.isEnded) {
+                parser.write(chunk);
+            }
+        },
+        finish: () => {
+            if (!parser.isEnded) {
+                parser.end();
+            }
+        },
+    };
+}
+```
+
+- [ ] **Step 2: Manual verification — run the parser against a real chunked Bundle**
+
+Run: `yarn dev`, then in the browser DevTools console on any page, paste and run:
+
+```js
+const { createBundleEntryParser } = await import('/src/utils/incrementalBundleParser.ts');
+const found = [];
+const p = createBundleEntryParser((r) => found.push(r), (e) => console.error('parser error', e));
+const bundle = { resourceType: 'Bundle', entry: [{ resource: { resourceType: 'Patient', id: '1' } }, { resource: { resourceType: 'Patient', id: '2' } }] };
+const text = JSON.stringify(bundle);
+const bytes = new TextEncoder().encode(text);
+for (let i = 0; i < bytes.length; i += 5) {
+    p.write(bytes.slice(i, i + 5));
+}
+p.finish();
+console.log('found', found.length, found);
+```
+
+Expected: `found` has length 2, containing the two Patient resources, no error logged, no thrown exception from `p.finish()`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/incrementalBundleParser.ts
+git commit -m "Add incremental Bundle-entry parser wrapping @streamparser/json"
+```
+
+---
+
+### Task 14: Wire incremental rendering into `IndexPage.tsx`'s search results
+
+**Files:**
+- Modify: `src/pages/IndexPage.tsx:153-232` (the `callApi` effect)
+
+**Interfaces:**
+- Consumes: `fhirApi.getBundleAsync(params, options)` from Task 12; `createBundleEntryParser(...)` from Task 13.
+
+- [ ] **Step 1: Feed streamed chunks into the incremental parser as the search bundle downloads**
+
+Add the import:
+
+```tsx
+import { createBundleEntryParser } from '../utils/incrementalBundleParser';
+```
+
+Inside `callApi`, before the `fhirApi.getBundleAsync({...})` call, only engage incremental rendering for the actual multi-resource search/list case (not the `shouldBeJsonFormat` raw-JSON view, which already renders the parsed result directly, and not single-resource reads, which have nothing to progressively render):
+
+```tsx
+const fhirApi = new FhirApi({
+    fhirUrl,
+    setUserDetails,
+    onRequest: recordRequest,
+});
+
+let incrementalResults: any[] = [];
+let parserFailed = false;
+const streamParser = shouldBeJsonFormat
+    ? undefined
+    : createBundleEntryParser(
+          (resource) => {
+              incrementalResults = [...incrementalResults, resource];
+              // Render each resource as it parses. The end-of-stream full JSON.parse result
+              // (below) still overwrites this once the response completes, so a parser miss
+              // never leaves the page silently short of data — it just skips the "populate
+              // live" effect for whatever wasn't caught incrementally.
+              setResources(incrementalResults);
+          },
+          (err) => {
+              console.error('Incremental bundle parsing failed, falling back to full parse:', err);
+              parserFailed = true;
+          }
+      );
+
+const { json, status: statusCode, incomplete } = await fhirApi.getBundleAsync(
+    {
+        resourceType,
+        id,
+        queryString,
+        operation: vid ? `_history/${vid}` : operation,
+    },
+    {
+        onChunk: streamParser
+            ? (chunk) => {
+                  if (!parserFailed) {
+                      streamParser.write(chunk);
+                  }
+              }
+            : undefined,
+    }
+);
+streamParser?.finish();
+```
+
+After the existing `setStatus(statusCode);` line, the existing logic already does:
+
+```tsx
+if (shouldBeJsonFormat) {
+    setResources(json);
+} else if (json && json.entry) {
+    setResources(json.entry);
+    setBundle(json);
+    ...
+```
+
+Leave this exactly as-is — `setResources(json.entry)` still runs once the full response is parsed, which is the authoritative final state (it overwrites whatever the incremental parser produced, so `Bundle.total`/pagination links and anything the parser missed are always correct in the end). Note one nuance: the incremental parser's `onEntry` receives the raw FHIR `resource` object, while `json.entry` is an array of `{ resource, ... }` wrapper objects — `getBox()`'s render already handles both shapes via `const resource = fullResource.resource || fullResource;`, so no rendering-code change is needed for that difference.
+
+Add the `incomplete` flag to the existing warning-less error path — right after `setStatus(statusCode);`, add:
+
+```tsx
+if (incomplete) {
+    console.warn('Search response was interrupted mid-stream; results may be incomplete until retried.');
+}
+```
+
+(A user-visible banner for this can be added later if it turns out to matter in practice — for now, matching what the API Console does with a full UI treatment would be scope creep on a page that doesn't have a dedicated status-chip area yet.)
+
+- [ ] **Step 2: Manual verification — resources populate progressively**
+
+Run: `yarn dev`, open DevTools → Network → throttle to "Slow 3G", then navigate to `http://localhost:5051/4_0_0/Patient?_count=20` (or any search returning several results):
+1. Watch the page as it loads — confirm `ResourceCard`s appear one at a time (or in small batches) as the response streams in, rather than all appearing at once at the very end.
+2. Once loading finishes, confirm the final list matches what you'd get without throttling (same count, same resources) — this proves the end-of-stream full parse correctly reconciles with the incremental one.
+3. Switch to `_format=json` on the same search (append `&_format=json` to the URL) and confirm that view still renders exactly as before (this path skips the incremental parser entirely per the `shouldBeJsonFormat` guard).
+4. Load a single-resource URL (e.g. `/4_0_0/Patient/<id>`) and confirm it still renders correctly (single-resource reads don't go through `getBundleAsync`'s entry-array path the same way, so this exercises the "existing behavior for non-list responses is untouched" guarantee).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/IndexPage.tsx
+git commit -m "Render search results incrementally as the Bundle streams in"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Shared client (Task 1–6), Tier A progress (Task 7–10, scoped per the noted deviation), Tier B incremental rendering (Task 11–14), error handling for aborts/mid-stream drops (built into `streamRequest()` in Task 1, surfaced via `incomplete` in Tasks 2/3/8/9/14), origin-lock preserved (Task 1). Testing section of the spec is replaced by the manual-verification steps per the Global Constraints note (Vitest deferred to a separate PR).
+- **Placeholder scan:** no TBD/TODO markers; every step has real code or a concrete manual-verification procedure.
+- **Type consistency:** `StreamRequestParams`/`StreamRequestResult` (Task 1) are used with identical field names throughout Tasks 2–14 (`bytesReceived`, `totalBytes`, `incomplete`, `onChunk`, `onProgress`) — verified no renamed variants crept in across tasks.

--- a/docs/superpowers/specs/2026-08-06-fhir-streaming-design.md
+++ b/docs/superpowers/specs/2026-08-06-fhir-streaming-design.md
@@ -1,0 +1,184 @@
+# Streaming FHIR Responses for Progressive Display
+
+**Status:** Draft for review
+**Date:** 2026-08-06
+
+## Problem
+
+Every page in this app that talks to the FHIR server does so through `BaseApi`
+(`src/api/baseApi.ts`), which wraps `axios` and buffers the entire HTTP
+response before the page sees anything. For large search Bundles, IPS
+summaries, or bulk `$everything` exports this means:
+
+- Users stare at a blank spinner until the *entire* response has downloaded
+  and been parsed, even though the FHIR server is sending data continuously.
+- Long-running requests are more exposed to any upstream idle-timeout
+  (browser, LB, proxy) because nothing about the request looks "alive" to
+  those layers until the buffered read resolves.
+
+One page already solves this: `src/pages/APIConsolePage.tsx`, via
+`FhirApi.sendRequest()`, reads the response with
+`response.body.getReader()` and surfaces status/headers and body chunks as
+they arrive. This design generalizes that pattern to the rest of the app.
+
+## Design principle: one shared client, no duplication
+
+A grep across `src` confirms every FHIR/admin call in the app is already
+funneled through exactly one of three classes — `BaseApi`, `FhirApi extends
+BaseApi`, `AdminApi extends BaseApi` — instantiated at 19 call sites, with
+zero pages calling `fetch()`/`axios` directly. This design **preserves and
+strengthens that invariant**: the only place streaming logic is implemented
+is `BaseApi.streamRequest()`; every page and every subclass method
+(`getData`, `request`, `downloadFile`, `getBundleAsync`, `sendRequest`, all
+`AdminApi` methods) is a thin wrapper over it. No page implements its own
+`fetch`/reader loop going forward — `APIConsolePage.tsx`'s bespoke streaming
+code is folded into the shared client rather than left as a one-off.
+
+`axios` remains a dependency only for the OIDC/auth services
+(`CognitoAuthService.ts`, `OktaAuthService.ts`,
+`ClientCredentialsAuthService.ts`, `BwellAppAuthService.ts`,
+`WellKnownConfigurationService.ts`, `Auth.tsx`) — those don't talk to the
+FHIR server and are out of scope for this change.
+
+## Architecture
+
+### 1. Shared streaming client (`BaseApi`)
+
+`BaseApi` gains one low-level method, `streamRequest()` — the current
+`FhirApi.sendRequest()` implementation moved up a level, generalized to
+binary-safe chunk handling (`Uint8Array`, not just decoded text) so it can
+back both JSON reads and blob downloads:
+
+```
+streamRequest({ method, urlString, data, headers, signal, onHeaders, onChunk }):
+  Promise<{ status, headers, bytes: Uint8Array, text: string, incomplete?: boolean }>
+```
+
+- Fires `onHeaders(status, headers)` as soon as `fetch()` resolves (before
+  the body streaming loop starts) — unchanged from today's behavior.
+- Reads `response.body.getReader()` in a loop, accumulating raw bytes and
+  calling `onChunk(chunk: Uint8Array)` per chunk.
+- A `TextDecoder({ stream: true })` derives `text` incrementally for callers
+  that want string chunks (the common case); binary callers use `bytes`
+  directly.
+- On a mid-stream drop, resolves with `incomplete: true` and whatever
+  partial data arrived (matches existing `sendRequest` behavior) rather than
+  throwing, so callers can decide how to degrade.
+- `FhirApi`'s origin-lock check (requests must stay on the configured FHIR
+  server) moves onto `streamRequest()` itself so every caller gets the
+  guarantee, not just the API Console's `sendRequest`.
+
+`getData()`, `request()`, and `downloadFile()` become wrappers:
+
+- `getData()` / `request()`: call `streamRequest()` with no `onChunk` (or an
+  internal one, see below), then `JSON.parse(text)` once complete — same
+  `{ status, json }` return shape as today, so the ~19 existing call sites
+  need **no changes** to keep working exactly as they do now.
+- `downloadFile()`: accumulates `Uint8Array` chunks and assembles a `Blob`
+  at the end instead of axios's `responseType: 'blob'`.
+- All three gain an optional `onProgress` callback parameter
+  (`(bytesReceived: number, totalBytes: number | undefined) => void`, total
+  from `Content-Length` when present) for pages that want a progress
+  indicator without full incremental parsing.
+
+This is Phase 1 and touches only `src/api/baseApi.ts` and
+`src/api/fhirApi.ts` (removing the now-redundant `sendRequest`, or keeping
+it as a thin FHIR-specific alias if `APIConsolePage.tsx` needs its exact
+current signature) — no page-level code changes required yet.
+
+### 2. Rendering strategy: hybrid
+
+FHIR Bundles are single JSON objects (`{ entry: [{resource: {...}}, ...] }`),
+not newline-delimited JSON, so partial text can't be `JSON.parse`d directly.
+Two tiers, chosen deliberately per page rather than applied uniformly
+(YAGNI: a single-resource read has nothing to progressively render beyond
+raw progress):
+
+**Tier A — progress indicator (all remaining FHIR-calling pages).** Pages
+pass `onProgress` into their existing `getData()`/`request()`/`downloadFile()`
+call and show a progress UI (percentage when `Content-Length` is known,
+otherwise a bytes-received counter or indeterminate "streaming…" state)
+instead of a static spinner. Content still renders once, fully parsed, when
+the stream completes. Applies to: `CompositionSummaryPage`, `IPSViewer`,
+`ExportStatus` (status polling + the bulk NDJSON download),
+`SpreadsheetViewer`, `FileDownload`, and all `AdminApi`-backed admin pages.
+
+**Tier B — true incremental rendering (`IndexPage`/`SearchPage` only).**
+This is the one page where users watch a *list* populate, so it's worth the
+extra investment: a browser-native streaming JSON parser,
+[`@streamparser/json`](https://github.com/juanjoDiaz/jsonparse2) (verified
+on npm, v0.0.23 at time of writing; built on Web Streams, no Node-stream
+shimming needed — unlike `stream-json` which targets Node), is fed each
+`onChunk` byte chunk and emits a
+JSONPath-addressable event each time a value completes. `IndexPage` listens
+for completed `entry[*].resource` values and appends each one to a growing
+`resources` state array as it arrives — `ResourceCard`s appear one at a
+time — instead of waiting for `bundle.entry.map(...)` over the full parsed
+object. Once the stream ends, the existing full-`JSON.parse(text)` result
+is used as the source of truth for anything the incremental pass didn't
+capture (e.g., `Bundle.total`, pagination links), so a parser edge case
+never produces a page that's silently missing data.
+
+### 3. Error handling
+
+- **Cancellation**: `AbortController`, wired through `signal` on
+  `streamRequest()` — already the pattern `APIConsolePage.tsx` uses for
+  stale-request cancellation; generalized so every page can cancel an
+  in-flight streamed request on unmount/re-query.
+- **Mid-stream drops**: `streamRequest()` resolves with `incomplete: true`
+  and best-effort partial data rather than rejecting (existing behavior in
+  `sendRequest`, generalized). Tier A pages show a "connection
+  interrupted — showing partial results" notice; Tier B's incremental list
+  keeps whatever resources already rendered and shows the same notice.
+- **Per-entry parse errors (Tier B only)**: a malformed individual entry is
+  logged and skipped in the incremental pass; it does not abort the stream,
+  and the end-of-stream full parse is still attempted as the fallback
+  source of truth.
+- **401 handling**: unchanged — `handleUnauthorized()` still fires off the
+  headers callback, before body streaming begins, same as today.
+- **Timeout scope**: there is no proxy/gateway in this repo (it's a pure
+  SPA calling the FHIR server directly), so nothing here can widen a
+  *hard* server-side total-duration timeout. What continuous chunked
+  delivery does address is *idle*-based timeouts (the common kind, e.g. LB
+  or browser inactivity timers) — as long as bytes keep flowing, those
+  don't fire. This is a resilience improvement, not a guarantee against
+  every timeout class.
+
+### 4. Rollout phases
+
+1. **Shared client**: `BaseApi.streamRequest()` + wrapped `getData` /
+   `request` / `downloadFile`, with `onProgress` support. No visible UI
+   change; existing pages keep working unchanged. Drop axios from
+   `BaseApi`.
+2. **Tier A progress UI**: a small shared `useStreamProgress`-style
+   indicator component, adopted by `CompositionSummaryPage`, `IPSViewer`,
+   `ExportStatus`, `SpreadsheetViewer`, `FileDownload`, admin pages.
+3. **Tier B incremental rendering**: `@streamparser/json` integration in
+   `IndexPage`/`SearchPage`, progressive `ResourceCard` list.
+
+### 5. Testing
+
+- Unit tests for `streamRequest()`: mock `ReadableStream` to verify
+  chunk/header callback ordering, `incomplete` handling on a simulated
+  drop, abort behavior, and binary vs. text accumulation.
+- Regression tests confirming `getData()`/`request()`/`downloadFile()`
+  return the same `{status, json}`/blob shape as the current axios-based
+  implementation, so all 19 existing call sites are unaffected by default.
+- Tier B: unit tests feeding a hand-built Bundle through the parser in
+  artificially small chunks (including chunk boundaries that split a token
+  or a UTF-8 multi-byte sequence) to confirm entries are emitted correctly
+  and in order, and that a deliberately malformed entry is skipped without
+  aborting the stream.
+- Per-page smoke tests (existing test setup, e.g. MSW-mocked responses)
+  updated to stream mock bodies in chunks rather than returning them
+  whole, so progressive-rendering assertions ("cards appear before the
+  full response completes") are meaningful rather than trivially true.
+
+## Open questions for implementation planning
+
+- Exact shape of the shared progress-indicator component/hook (Tier A) —
+  left for the implementation plan rather than this design.
+- Whether `FhirApi.sendRequest()` is kept as a named method for
+  `APIConsolePage.tsx` (which also renders raw streamed text, not just
+  progress) or whether the console adopts the same `onChunk` shape as
+  everyone else.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@mui/material": "^9.0.1",
     "@mui/x-date-pickers": "^9.3.0",
     "@sentry/react": "10.53.1",
+    "@streamparser/json": "^0.0.23",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -303,22 +303,21 @@ class BaseApi {
         return { status, json, incomplete };
     }
 
-    async downloadFile(url: string): Promise<any> {
-        try {
-            const response = await this.axiosInstance.get(url, {
-                responseType: 'blob',
-            });
-            return {
-                status: response.status,
-                data: response.data,
-                headers: response.headers
-            };
-        } catch (err: any) {
-            if (err.response?.status === 401 && this.setUserDetails) {
-                await logout(this.setUserDetails);
-            }
-            throw err;
+    async downloadFile(
+        url: string,
+        options?: { onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void }
+    ): Promise<{ status: number; data: Blob; headers: Record<string, string> }> {
+        const { status, bytes, headers } = await this.streamRequest({
+            method: 'GET',
+            urlString: url,
+            responseMode: 'binary',
+            onProgress: options?.onProgress,
+        });
+        if (!status || status < 200 || status >= 300) {
+            throw Object.assign(new Error(`Request failed with status ${status}`), { status });
         }
+        const contentType = headers['content-type'] || 'application/octet-stream';
+        return { status, data: new Blob([new Uint8Array(bytes)], { type: contentType }), headers };
     }
 
     requestInterceptor(req: InternalAxiosRequestConfig<any>): InternalAxiosRequestConfig<any> {

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -36,6 +36,7 @@ export interface StreamRequestResult {
     bytes: Uint8Array;
     text: string;
     incomplete: boolean;
+    errorMessage?: string;
 }
 
 class BaseApi {
@@ -174,7 +175,20 @@ class BaseApi {
             if (err?.name === 'AbortError') {
                 throw err;
             }
-            return { status: undefined, headers: {}, bytes: new Uint8Array(0), text: '', incomplete: true };
+            // Surface the underlying error message (network failure, CORS block, DNS failure,
+            // etc.) via a dedicated field rather than folding it into `text` — callers like
+            // getData()/request()/downloadFile() parse `text` as the response body and must keep
+            // seeing an empty body on total network failure (matching the old axios-based
+            // behavior). Only FhirApi.sendRequest() reads `errorMessage` today, to restore its
+            // pre-refactor diagnostic behavior for the API Console.
+            return {
+                status: undefined,
+                headers: {},
+                bytes: new Uint8Array(0),
+                text: '',
+                incomplete: true,
+                errorMessage: err?.message || 'Request failed',
+            };
         }
 
         const responseHeaders: Record<string, string> = {};

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -1,6 +1,4 @@
 import React from 'react';
-import axios, { AxiosInstance } from 'axios';
-import { InternalAxiosRequestConfig } from 'axios';
 import { getLocalData } from '../utils/localData.utils';
 import { TUserDetails } from '../types/baseTypes';
 import AuthUrlProvider from '../utils/authUrlProvider';
@@ -45,7 +43,6 @@ class BaseApi {
     private readonly setUserDetails:
         | React.Dispatch<React.SetStateAction<TUserDetails | null>>
         | undefined;
-    private readonly axiosInstance: AxiosInstance;
     protected readonly onRequest?: (info: TRequestInfo) => void;
 
     constructor({
@@ -60,10 +57,6 @@ class BaseApi {
         this.fhirUrl = fhirUrl;
         this.setUserDetails = setUserDetails;
         this.onRequest = onRequest;
-
-        // Create a dedicated axios instance for this BaseApi instance
-        this.axiosInstance = axios.create();
-        this.axiosInstance.interceptors.request.use(this.requestInterceptor.bind(this));
     }
 
     protected getBaseUrl(): string {
@@ -320,13 +313,6 @@ class BaseApi {
         return { status, data: new Blob([bytes as Uint8Array<ArrayBuffer>], { type: contentType }), headers };
     }
 
-    requestInterceptor(req: InternalAxiosRequestConfig<any>): InternalAxiosRequestConfig<any> {
-        const headers = this.buildHeaders();
-        Object.entries(headers).forEach(([key, value]) => {
-            req.headers[key] = value;
-        });
-        return req;
-    }
 }
 
 export default BaseApi;

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -317,7 +317,7 @@ class BaseApi {
             throw Object.assign(new Error(`Request failed with status ${status}`), { status });
         }
         const contentType = headers['content-type'] || 'application/octet-stream';
-        return { status, data: new Blob([new Uint8Array(bytes)], { type: contentType }), headers };
+        return { status, data: new Blob([bytes as Uint8Array<ArrayBuffer>], { type: contentType }), headers };
     }
 
     requestInterceptor(req: InternalAxiosRequestConfig<any>): InternalAxiosRequestConfig<any> {

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -209,56 +209,85 @@ class BaseApi {
             ? parseInt(responseHeaders['content-length'], 10)
             : undefined;
 
-        const receivedChunks: Uint8Array[] = [];
-        let receivedBytes = 0;
         const decoder = new TextDecoder();
-        let text = '';
+        const { chunks, text: bodyText, incomplete } = await this.readStreamedBody({
+            response,
+            responseMode,
+            decoder,
+            onChunk,
+            onProgress,
+            totalBytes,
+        });
 
-        const finalize = (incomplete: boolean): StreamRequestResult => {
-            // Flush any dangling partial multi-byte UTF-8 sequence buffered internally by the
-            // decoder from the last `{ stream: true }` call — without this, a chunk boundary that
-            // splits a multi-byte character at the very end of the body silently drops it from
-            // `text`. Calling decode() with no arguments (equivalent to `{ stream: false }`) is
-            // safe to call even when nothing is buffered (returns '').
-            if (responseMode === 'text') {
-                text += decoder.decode();
+        // Flush any dangling partial multi-byte UTF-8 sequence buffered internally by the
+        // decoder from the last `{ stream: true }` call — without this, a chunk boundary that
+        // splits a multi-byte character at the very end of the body silently drops it from
+        // `text`. Calling decode() with no arguments (equivalent to `{ stream: false }`) is
+        // safe to call even when nothing is buffered (returns '').
+        const text = responseMode === 'text' ? bodyText + decoder.decode() : bodyText;
+
+        return { status: response.status, headers: responseHeaders, chunks, text, incomplete };
+    }
+
+    // Extracted from streamRequest() to keep control-flow nesting shallow: this owns the
+    // response.body reader loop (and the bodyless-response fallback) as its own scope, and
+    // catches a mid-stream drop internally so it can return whatever partial chunks/text
+    // already arrived — the caller doesn't need its own try/catch around this.
+    private async readStreamedBody({
+        response,
+        responseMode,
+        decoder,
+        onChunk,
+        onProgress,
+        totalBytes,
+    }: {
+        response: Response;
+        responseMode: 'text' | 'binary';
+        decoder: TextDecoder;
+        onChunk?: (chunk: Uint8Array) => void;
+        onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void;
+        totalBytes: number | undefined;
+    }): Promise<{ chunks: Uint8Array[]; text: string; incomplete: boolean }> {
+        if (!response.body) {
+            if (responseMode !== 'text') {
+                return { chunks: [], text: '', incomplete: false };
             }
-            return { status: response.status, headers: responseHeaders, chunks: receivedChunks, text, incomplete };
-        };
+            const text = await response.text();
+            onChunk?.(new TextEncoder().encode(text));
+            onProgress?.(text.length, totalBytes);
+            return { chunks: [], text, incomplete: false };
+        }
 
+        const reader = response.body.getReader();
+        const chunks: Uint8Array[] = [];
+        let text = '';
+        let receivedBytes = 0;
         try {
-            if (response.body) {
-                const reader = response.body.getReader();
-                let done = false;
-                while (!done) {
-                    const result = await reader.read();
-                    done = result.done;
-                    if (result.value) {
-                        receivedChunks.push(result.value);
-                        receivedBytes += result.value.length;
-                        if (responseMode === 'text') {
-                            text += decoder.decode(result.value, { stream: true });
-                        }
-                        onChunk?.(result.value);
-                        onProgress?.(receivedBytes, totalBytes);
-                    }
+            let done = false;
+            while (!done) {
+                const result = await reader.read();
+                done = result.done;
+                if (!result.value) {
+                    continue;
                 }
-            } else if (responseMode === 'text') {
-                text = await response.text();
-                onChunk?.(new TextEncoder().encode(text));
-                onProgress?.(text.length, totalBytes);
+                chunks.push(result.value);
+                receivedBytes += result.value.length;
+                if (responseMode === 'text') {
+                    text += decoder.decode(result.value, { stream: true });
+                }
+                onChunk?.(result.value);
+                onProgress?.(receivedBytes, totalBytes);
             }
         } catch (err: any) {
             if (err?.name === 'AbortError') {
                 throw err;
             }
             // A mid-stream drop rejects here. Headers were already surfaced via onHeaders and
-            // whatever bytes arrived via onChunk, so resolve with the partial data instead of
-            // throwing — callers decide how to degrade rather than losing everything.
-            return finalize(true);
+            // whatever bytes arrived via onChunk, so return the partial data instead of
+            // throwing — the caller decides how to degrade rather than losing everything.
+            return { chunks, text, incomplete: true };
         }
-
-        return finalize(false);
+        return { chunks, text, incomplete: false };
     }
 
     async getData(
@@ -312,7 +341,7 @@ class BaseApi {
         url: string,
         options?: { onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void }
     ): Promise<{ status: number; data: Blob; headers: Record<string, string> }> {
-        const { status, chunks, headers, errorMessage } = await this.streamRequest({
+        const { status, chunks, headers, errorMessage, incomplete } = await this.streamRequest({
             method: 'GET',
             urlString: url,
             responseMode: 'binary',
@@ -320,6 +349,18 @@ class BaseApi {
         });
         if (!status || status < 200 || status >= 300) {
             throw Object.assign(new Error(errorMessage || `Request failed with status ${status}`), { status });
+        }
+        if (incomplete) {
+            // streamRequest() still reports the original 2xx status captured when fetch()
+            // resolved, before the body finished — a mid-download connection drop would
+            // otherwise look like a normal successful download and hand callers a silently
+            // truncated Blob. Throwing here restores the pre-refactor axios behavior (a dropped
+            // connection rejected the promise), which both FileDownload.tsx and
+            // SpreadsheetViewer.tsx already handle with a visible error in their catch blocks.
+            throw Object.assign(new Error('Connection interrupted before the download finished'), {
+                status,
+                incomplete: true,
+            });
         }
         const contentType = headers['content-type'] || 'application/octet-stream';
         return {

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -279,30 +279,28 @@ class BaseApi {
         return { status, json, incomplete };
     }
 
-    async request({ urlString, params, method, data }: RequestParams): Promise<any> {
-        // Unlike getData, this doesn't normalize urlString to a relative pathname+search (it
-        // may still carry an origin) and it ignores `params` (which axios appends to the query
-        // string below) — so the captured url can diverge from what's actually requested. No
-        // reachable caller passes onRequest today (see FhirApi.mergeResource), so this is a
-        // known gap for whoever gives this method its first real caller, not a live bug.
-        this.onRequest?.({ method, url: urlString });
-
-        try {
-            const response = await this.axiosInstance.request({
-                baseURL: this.getBaseUrl(),
-                url: urlString,
-                method,
-                params,
-                data,
-                headers: {
-                    'Content-Type': 'application/fhir+json'
-                }
-            });
-            return { status: response.status, json: response.data };
-        } catch (err: any) {
-            await this.handleUnauthorized(err.response?.status);
-            return { status: err.response?.status, json: err.response?.data };
+    async request(
+        { urlString, params, method, data }: RequestParams,
+        options?: {
+            onChunk?: (chunk: Uint8Array) => void;
+            onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void;
         }
+    ): Promise<{ status: number | undefined; json: any; incomplete: boolean }> {
+        const { status, text, incomplete } = await this.streamRequest({
+            method,
+            urlString,
+            params,
+            data,
+            onChunk: options?.onChunk,
+            onProgress: options?.onProgress,
+        });
+        let json: any;
+        try {
+            json = text ? JSON.parse(text) : undefined;
+        } catch {
+            json = undefined;
+        }
+        return { status, json, incomplete };
     }
 
     async downloadFile(url: string): Promise<any> {

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -19,6 +19,27 @@ interface RequestParams {
     data?: any;
 }
 
+export interface StreamRequestParams {
+    method: HttpMethod;
+    urlString: string;
+    params?: Record<string, string>;
+    data?: any;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+    responseMode?: 'text' | 'binary';
+    onHeaders?: (status: number, headers: Record<string, string>) => void;
+    onChunk?: (chunk: Uint8Array) => void;
+    onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void;
+}
+
+export interface StreamRequestResult {
+    status: number | undefined;
+    headers: Record<string, string>;
+    bytes: Uint8Array;
+    text: string;
+    incomplete: boolean;
+}
+
 class BaseApi {
     private readonly fhirUrl: string | undefined;
     private readonly setUserDetails:
@@ -103,6 +124,128 @@ class BaseApi {
 
     async getVersion(): Promise<string> {
         return (await this.getData({ urlString: '/version' })).json?.version;
+    }
+
+    async streamRequest({
+        method,
+        urlString,
+        params,
+        data,
+        headers,
+        signal,
+        responseMode = 'text',
+        onHeaders,
+        onChunk,
+        onProgress,
+    }: StreamRequestParams): Promise<StreamRequestResult> {
+        let path = urlString;
+        if (path.startsWith(window.location.origin)) {
+            path = path.slice(window.location.origin.length);
+        }
+        const url = new URL(path, this.getBaseUrl());
+        if (params) {
+            Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
+        }
+
+        // The session's bearer token must never leave the configured base URL. A scheme-relative
+        // or absolute path can resolve to a different origin via `new URL()`, so refuse before any
+        // fetch happens rather than trusting every caller to have validated its own input. This
+        // check used to live only in FhirApi.sendRequest (the one caller that took a free-form path
+        // from user input); moving it here means every BaseApi-derived call gets the guarantee.
+        if (url.origin !== new URL(this.getBaseUrl()).origin) {
+            return {
+                status: undefined,
+                headers: {},
+                bytes: new Uint8Array(0),
+                text: JSON.stringify({ error: 'Request path must stay on the configured FHIR server' }),
+                incomplete: false,
+            };
+        }
+
+        this.onRequest?.({ method, url: url.pathname + url.search });
+
+        const requestHeaders = this.buildHeaders({
+            'Content-Type': 'application/fhir+json',
+            ...headers,
+        });
+
+        let response: Response;
+        try {
+            response = await fetch(url.toString(), {
+                method,
+                headers: requestHeaders,
+                body: data !== undefined && data !== null ? JSON.stringify(data) : undefined,
+                signal,
+            });
+        } catch (err: any) {
+            if (err?.name === 'AbortError') {
+                throw err;
+            }
+            return { status: undefined, headers: {}, bytes: new Uint8Array(0), text: '', incomplete: true };
+        }
+
+        const responseHeaders: Record<string, string> = {};
+        response.headers.forEach((value, key) => {
+            responseHeaders[key] = value;
+        });
+
+        // Surface status/headers as soon as fetch() resolves — before the body streaming loop
+        // below starts — so callers can populate UI without waiting for the whole body.
+        onHeaders?.(response.status, responseHeaders);
+        await this.handleUnauthorized(response.status);
+
+        const totalBytes = responseHeaders['content-length']
+            ? parseInt(responseHeaders['content-length'], 10)
+            : undefined;
+
+        const receivedChunks: Uint8Array[] = [];
+        let receivedBytes = 0;
+        const decoder = new TextDecoder();
+        let text = '';
+
+        const finalize = (incomplete: boolean): StreamRequestResult => {
+            const bytes = new Uint8Array(receivedBytes);
+            let offset = 0;
+            for (const chunk of receivedChunks) {
+                bytes.set(chunk, offset);
+                offset += chunk.length;
+            }
+            return { status: response.status, headers: responseHeaders, bytes, text, incomplete };
+        };
+
+        try {
+            if (response.body) {
+                const reader = response.body.getReader();
+                let done = false;
+                while (!done) {
+                    const result = await reader.read();
+                    done = result.done;
+                    if (result.value) {
+                        receivedChunks.push(result.value);
+                        receivedBytes += result.value.length;
+                        if (responseMode === 'text') {
+                            text += decoder.decode(result.value, { stream: true });
+                        }
+                        onChunk?.(result.value);
+                        onProgress?.(receivedBytes, totalBytes);
+                    }
+                }
+            } else if (responseMode === 'text') {
+                text = await response.text();
+                onChunk?.(new TextEncoder().encode(text));
+                onProgress?.(text.length, totalBytes);
+            }
+        } catch (err: any) {
+            if (err?.name === 'AbortError') {
+                throw err;
+            }
+            // A mid-stream drop rejects here. Headers were already surfaced via onHeaders and
+            // whatever bytes arrived via onChunk, so resolve with the partial data instead of
+            // throwing — callers decide how to degrade rather than losing everything.
+            return finalize(true);
+        }
+
+        return finalize(false);
     }
 
     async getData({ urlString, params }: GetDataParams): Promise<any> {

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -210,6 +210,14 @@ class BaseApi {
                 bytes.set(chunk, offset);
                 offset += chunk.length;
             }
+            // Flush any dangling partial multi-byte UTF-8 sequence buffered internally by the
+            // decoder from the last `{ stream: true }` call — without this, a chunk boundary that
+            // splits a multi-byte character at the very end of the body silently drops it from
+            // `text`. Calling decode() with no arguments (equivalent to `{ stream: false }`) is
+            // safe to call even when nothing is buffered (returns '').
+            if (responseMode === 'text') {
+                text += decoder.decode();
+            }
             return { status: response.status, headers: responseHeaders, bytes, text, incomplete };
         };
 

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -256,24 +256,27 @@ class BaseApi {
         return finalize(false);
     }
 
-    async getData({ urlString, params }: GetDataParams): Promise<any> {
-        if (urlString.includes(window.location.origin)) {
-            urlString = urlString.replace(window.location.origin, '');
+    async getData(
+        { urlString, params }: GetDataParams,
+        options?: {
+            onChunk?: (chunk: Uint8Array) => void;
+            onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void;
         }
-        const url = new URL(urlString, this.getBaseUrl());
-        if (params && Object.keys(params).length > 0) {
-            url.search = new URLSearchParams(params).toString();
-        }
-
-        this.onRequest?.({ method: 'GET', url: url.pathname + url.search });
-
+    ): Promise<{ status: number | undefined; json: any; incomplete: boolean }> {
+        const { status, text, incomplete } = await this.streamRequest({
+            method: 'GET',
+            urlString,
+            params,
+            onChunk: options?.onChunk,
+            onProgress: options?.onProgress,
+        });
+        let json: any;
         try {
-            const response = await this.axiosInstance.get(url.toString());
-            return { status: response.status, json: response.data };
-        } catch (err: any) {
-            await this.handleUnauthorized(err.response?.status);
-            return { status: err.response?.status, json: err.response?.data };
+            json = text ? JSON.parse(text) : undefined;
+        } catch {
+            json = undefined;
         }
+        return { status, json, incomplete };
     }
 
     async request({ urlString, params, method, data }: RequestParams): Promise<any> {

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -33,7 +33,7 @@ export interface StreamRequestParams {
 export interface StreamRequestResult {
     status: number | undefined;
     headers: Record<string, string>;
-    bytes: Uint8Array;
+    chunks: Uint8Array[];
     text: string;
     incomplete: boolean;
     errorMessage?: string;
@@ -150,7 +150,7 @@ class BaseApi {
             return {
                 status: undefined,
                 headers: {},
-                bytes: new Uint8Array(0),
+                chunks: [],
                 text: JSON.stringify({ error: 'Request path must stay on the configured FHIR server' }),
                 incomplete: false,
             };
@@ -184,7 +184,7 @@ class BaseApi {
             return {
                 status: undefined,
                 headers: {},
-                bytes: new Uint8Array(0),
+                chunks: [],
                 text: '',
                 incomplete: true,
                 errorMessage: err?.message || 'Request failed',
@@ -201,7 +201,11 @@ class BaseApi {
         onHeaders?.(response.status, responseHeaders);
         await this.handleUnauthorized(response.status);
 
-        const totalBytes = responseHeaders['content-length']
+        // Content-Length reflects the compressed size when the server sends a Content-Encoding
+        // (gzip/br/deflate), but reader.read() yields decompressed bytes — comparing the two would
+        // make the progress percentage race past 100%. Treat the total as unknown whenever the
+        // response is encoded; the indicator falls back to an indeterminate progress bar.
+        const totalBytes = !responseHeaders['content-encoding'] && responseHeaders['content-length']
             ? parseInt(responseHeaders['content-length'], 10)
             : undefined;
 
@@ -211,12 +215,6 @@ class BaseApi {
         let text = '';
 
         const finalize = (incomplete: boolean): StreamRequestResult => {
-            const bytes = new Uint8Array(receivedBytes);
-            let offset = 0;
-            for (const chunk of receivedChunks) {
-                bytes.set(chunk, offset);
-                offset += chunk.length;
-            }
             // Flush any dangling partial multi-byte UTF-8 sequence buffered internally by the
             // decoder from the last `{ stream: true }` call — without this, a chunk boundary that
             // splits a multi-byte character at the very end of the body silently drops it from
@@ -225,7 +223,7 @@ class BaseApi {
             if (responseMode === 'text') {
                 text += decoder.decode();
             }
-            return { status: response.status, headers: responseHeaders, bytes, text, incomplete };
+            return { status: response.status, headers: responseHeaders, chunks: receivedChunks, text, incomplete };
         };
 
         try {
@@ -314,17 +312,21 @@ class BaseApi {
         url: string,
         options?: { onProgress?: (bytesReceived: number, totalBytes: number | undefined) => void }
     ): Promise<{ status: number; data: Blob; headers: Record<string, string> }> {
-        const { status, bytes, headers } = await this.streamRequest({
+        const { status, chunks, headers, errorMessage } = await this.streamRequest({
             method: 'GET',
             urlString: url,
             responseMode: 'binary',
             onProgress: options?.onProgress,
         });
         if (!status || status < 200 || status >= 300) {
-            throw Object.assign(new Error(`Request failed with status ${status}`), { status });
+            throw Object.assign(new Error(errorMessage || `Request failed with status ${status}`), { status });
         }
         const contentType = headers['content-type'] || 'application/octet-stream';
-        return { status, data: new Blob([bytes as Uint8Array<ArrayBuffer>], { type: contentType }), headers };
+        return {
+            status,
+            data: new Blob(chunks as Uint8Array<ArrayBuffer>[], { type: contentType }),
+            headers,
+        };
     }
 
 }

--- a/src/api/fhirApi.ts
+++ b/src/api/fhirApi.ts
@@ -157,7 +157,15 @@ class FhirApi extends BaseApi {
 
         let json: any;
         try {
-            json = result.text ? JSON.parse(result.text) : undefined;
+            // On a total fetch-level failure (network error, CORS block, DNS failure — not an
+            // abort), streamRequest() returns an empty `text` but sets `errorMessage`. Surface
+            // that as `{ error: ... }` so the API Console shows the real failure reason instead
+            // of a blank response, matching this method's pre-refactor behavior.
+            json = result.text
+                ? JSON.parse(result.text)
+                : result.errorMessage
+                    ? { error: result.errorMessage }
+                    : undefined;
         } catch {
             json = undefined;
         }

--- a/src/api/fhirApi.ts
+++ b/src/api/fhirApi.ts
@@ -140,110 +140,35 @@ class FhirApi extends BaseApi {
         rawText: string;
         incomplete?: boolean;
     }> {
-        let path = urlPath;
-        if (path.startsWith(window.location.origin)) {
-            path = path.slice(window.location.origin.length);
-        }
-        const url = new URL(path, this.getBaseUrl());
-
-        // The session's bearer token must never leave the configured FHIR server. A
-        // scheme-relative path (e.g. "//evil.com/collect") resolves to a different origin via
-        // new URL(), so compare the resolved origin against the base URL's origin and refuse
-        // before any fetch happens. This is the single chokepoint every URL mode goes through
-        // (guided builder and free-form path alike), so the invariant can't be re-broken in the UI.
-        if (url.origin !== new URL(this.getBaseUrl()).origin) {
-            return {
-                status: undefined,
-                json: { error: 'Request path must stay on the configured FHIR server' },
-                headers: {},
-                rawText: '',
-            };
-        }
-
-        this.onRequest?.({ method, url: url.pathname + url.search });
-
-        const requestHeaders = this.buildHeaders({
-            'Content-Type': 'application/fhir+json',
-            ...headers,
+        // APIConsolePage's onChunk expects decoded text, but streamRequest hands back raw
+        // Uint8Array chunks (so binary downloads elsewhere aren't forced through a decoder). Keep
+        // one TextDecoder alive across the whole request — decoding each chunk independently would
+        // corrupt any multi-byte UTF-8 character split across a chunk boundary.
+        const decoder = new TextDecoder();
+        const result = await this.streamRequest({
+            method,
+            urlString: urlPath,
+            data,
+            headers,
+            signal,
+            onHeaders,
+            onChunk: onChunk ? (chunk) => onChunk(decoder.decode(chunk, { stream: true })) : undefined,
         });
-
-        let response: Response;
-        try {
-            response = await fetch(url.toString(), {
-                method,
-                headers: requestHeaders,
-                body: data !== undefined ? JSON.stringify(data) : undefined,
-                signal,
-            });
-        } catch (err: any) {
-            if (err?.name === 'AbortError') {
-                throw err;
-            }
-            return { status: undefined, json: { error: err.message || 'Request failed' }, headers: {}, rawText: '' };
-        }
-
-        const responseHeaders: Record<string, string> = {};
-        response.headers.forEach((value, key) => {
-            responseHeaders[key] = value;
-        });
-
-        // Surface status/headers to the caller as soon as fetch() resolves — i.e. before the
-        // body streaming loop below starts — so the UI can populate them without waiting for
-        // the whole body to arrive.
-        onHeaders?.(response.status, responseHeaders);
-
-        await this.handleUnauthorized(response.status);
-
-        let rawText = '';
-        try {
-            if (response.body) {
-                const reader = response.body.getReader();
-                const decoder = new TextDecoder();
-                let done = false;
-                while (!done) {
-                    const result = await reader.read();
-                    done = result.done;
-                    if (result.value) {
-                        const chunkText = decoder.decode(result.value, { stream: true });
-                        rawText += chunkText;
-                        onChunk?.(chunkText);
-                    }
-                }
-            } else {
-                rawText = await response.text();
-                onChunk?.(rawText);
-            }
-        } catch (err: any) {
-            if (err?.name === 'AbortError') {
-                throw err;
-            }
-            // A mid-stream connection drop rejects here. The status/headers were already
-            // surfaced via onHeaders and the partial body via onChunk, so resolve with what
-            // arrived instead of throwing — the caller's catch-all would otherwise discard
-            // both in favor of a generic error.
-            let partialJson: any;
-            try {
-                partialJson = rawText ? JSON.parse(rawText) : undefined;
-            } catch {
-                partialJson = undefined;
-            }
-            return {
-                status: response.status,
-                json: partialJson,
-                headers: responseHeaders,
-                rawText,
-                incomplete: true,
-            };
-        }
 
         let json: any;
         try {
-            json = rawText ? JSON.parse(rawText) : undefined;
+            json = result.text ? JSON.parse(result.text) : undefined;
         } catch {
             json = undefined;
         }
 
-        return { status: response.status, json, headers: responseHeaders, rawText };
+        return {
+            status: result.status,
+            json,
+            headers: result.headers,
+            rawText: result.text,
+            incomplete: result.incomplete,
+        };
     }
 }
 

--- a/src/api/fhirApi.ts
+++ b/src/api/fhirApi.ts
@@ -42,7 +42,7 @@ class FhirApi extends BaseApi {
         queryString,
         queryParameters,
         operation,
-    }: GetBundleAsyncParams): Promise<{ status: number; json: any }> {
+    }: GetBundleAsyncParams): Promise<{ status: number | undefined; json: any }> {
         const url = this.getUrl({
             resourceType,
             id,

--- a/src/api/fhirApi.ts
+++ b/src/api/fhirApi.ts
@@ -36,13 +36,16 @@ class FhirApi extends BaseApi {
         return await this.getData({urlString});
     }
 
-    async getBundleAsync({
-        resourceType,
-        id,
-        queryString,
-        queryParameters,
-        operation,
-    }: GetBundleAsyncParams): Promise<{ status: number | undefined; json: any }> {
+    async getBundleAsync(
+        {
+            resourceType,
+            id,
+            queryString,
+            queryParameters,
+            operation,
+        }: GetBundleAsyncParams,
+        options?: { onChunk?: (chunk: Uint8Array) => void }
+    ): Promise<{ status: number | undefined; json: any; incomplete: boolean }> {
         const url = this.getUrl({
             resourceType,
             id,
@@ -50,7 +53,7 @@ class FhirApi extends BaseApi {
             queryParameters,
             operation,
         });
-        return await this.getData({urlString: url.toString()});
+        return await this.getData({urlString: url.toString()}, options);
     }
 
     addMissingRequiredParams({

--- a/src/components/FileDownload.tsx
+++ b/src/components/FileDownload.tsx
@@ -5,6 +5,8 @@ import { saveAs } from 'file-saver';
 import EnvironmentContext from '../context/EnvironmentContext';
 import UserContext from '../context/UserContext';
 import BaseApi from '../api/baseApi';
+import { useStreamProgress } from '../hooks/useStreamProgress';
+import StreamProgressIndicator from './StreamProgressIndicator';
 
 interface FileDownloadProps {
     relativeUrl: string;
@@ -16,6 +18,7 @@ const FileDownload: React.FC<FileDownloadProps> = ({ relativeUrl, format }) => {
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const { fhirUrl } = useContext(EnvironmentContext);
     const { setUserDetails } = useContext(UserContext);
+    const { progress, start, onProgress, finish } = useStreamProgress();
     const baseApi = React.useMemo(
         () => new BaseApi({ fhirUrl, setUserDetails }),
         [fhirUrl, setUserDetails]
@@ -40,31 +43,31 @@ const FileDownload: React.FC<FileDownloadProps> = ({ relativeUrl, format }) => {
         e.preventDefault();
         setIsLoading(true);
         setErrorMessage(null); // Clear any previous error message
+        start();
         try {
-            const response = await baseApi.downloadFile(downloadUri.toString());
+            const response = await baseApi.downloadFile(downloadUri.toString(), { onProgress });
 
             const contentDisposition = response.headers['content-disposition'];
             if (!contentDisposition) {
                 console.error('Content-Disposition header not found');
                 setErrorMessage('Failed to download the file: Missing Content-Disposition header.');
-                setIsLoading(false);
                 return;
             }
             const filename = extractFilenameFromHeader(contentDisposition);
             if (!filename) {
                 console.error('Filename not found in Content-Disposition header');
                 setErrorMessage('Filename not found in Content-Disposition header.');
-                setIsLoading(false);
                 return;
             }
             saveAs(response.data, filename);
-            setIsLoading(false);
         } catch (error1: unknown) {
             console.error('Error downloading the file:', error1);
             setErrorMessage(
                 `An error occurred while downloading the file: ${(error1 as Error).message}`
             );
+        } finally {
             setIsLoading(false);
+            finish();
         }
     };
 
@@ -75,6 +78,7 @@ const FileDownload: React.FC<FileDownloadProps> = ({ relativeUrl, format }) => {
                     {errorMessage}
                 </Alert>
             )}
+            {isLoading && <StreamProgressIndicator progress={progress} />}
             <Tooltip title="Download" arrow>
                 <Link
                     component="button"

--- a/src/components/IPSViewer.tsx
+++ b/src/components/IPSViewer.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useState, useEffect } from 'react';
 import {
     Typography,
     Box,
-    CircularProgress,
     Alert,
     Card,
     CardContent,
@@ -25,6 +24,8 @@ import './IPSNarrative.css'; // Import the CSS file for styling the IPS narrativ
 import PreJson from './PreJson';
 import { getMandatorySectionContent } from '../constants/ipsConstants';
 import { appendFormatJson } from '../utils/url.utils';
+import { useStreamProgress } from '../hooks/useStreamProgress';
+import StreamProgressIndicator from './StreamProgressIndicator';
 
 interface IPSViewerProps {
     relativeUrl: string;
@@ -73,6 +74,8 @@ const IPSViewer: React.FC<IPSViewerProps> = ({ relativeUrl }) => {
     const [sectionData, setSectionData] = useState<SectionData[]>([]);
     const [collapsedResourceTypes, setCollapsedResourceTypes] = useState<Set<string>>(new Set());
     const [bundleResourcesCollapsed, setBundleResourcesCollapsed] = useState<boolean>(true);
+    const [isIncomplete, setIsIncomplete] = useState<boolean>(false);
+    const { progress, start, onProgress, finish } = useStreamProgress();
     const { isDarkMode } = useTheme();
 
     const { fhirUrl } = useContext(EnvironmentContext);
@@ -229,11 +232,14 @@ const IPSViewer: React.FC<IPSViewerProps> = ({ relativeUrl }) => {
         const fetchBundle = async () => {
             setIsLoading(true);
             setErrorMessage(null);
+            setIsIncomplete(false);
+            start();
 
             try {
-                const response = await baseApi.getData({ urlString: relativeUrl });
+                const response = await baseApi.getData({ urlString: relativeUrl }, { onProgress });
                 const bundleData: Bundle = response.json;
                 setRawResponse(bundleData);
+                setIsIncomplete(response.incomplete);
 
                 // Extract the HTML content from the first Composition resource
                 const compositionEntry = bundleData.entry?.find(
@@ -305,16 +311,17 @@ const IPSViewer: React.FC<IPSViewerProps> = ({ relativeUrl }) => {
                 setErrorMessage('Failed to load the International Patient Summary');
             } finally {
                 setIsLoading(false);
+                finish();
             }
         };
 
         fetchBundle();
-    }, [relativeUrl, baseApi]);
+    }, [relativeUrl, baseApi, start, onProgress, finish]);
 
     if (isLoading) {
         return (
-            <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
-                <CircularProgress />
+            <Box sx={{ my: 4 }}>
+                <StreamProgressIndicator progress={progress} />
             </Box>
         );
     }
@@ -330,6 +337,11 @@ const IPSViewer: React.FC<IPSViewerProps> = ({ relativeUrl }) => {
 
     return (
         <Box sx={{ width: '100%', mb: 4 }}>
+            {isIncomplete && (
+                <Alert severity="warning" sx={{ mb: 2 }}>
+                    Connection interrupted — showing partial results.
+                </Alert>
+            )}
             <Box
                 sx={{
                     display: 'flex',

--- a/src/components/SpreadsheetViewer.tsx
+++ b/src/components/SpreadsheetViewer.tsx
@@ -4,7 +4,6 @@ import { read, utils, type WorkBook } from 'xlsx';
 import {
     Typography,
     Box,
-    CircularProgress,
     Alert,
     Tabs,
     Tab,
@@ -14,6 +13,8 @@ import {
 import EnvironmentContext from '../context/EnvironmentContext';
 import UserContext from '../context/UserContext';
 import BaseApi from '../api/baseApi';
+import { useStreamProgress } from '../hooks/useStreamProgress';
+import StreamProgressIndicator from './StreamProgressIndicator';
 import {
     ModuleRegistry,
     ColumnAutoSizeModule,
@@ -78,6 +79,8 @@ const SpreadsheetViewer: React.FC<SpreadsheetViewerProps> = ({ relativeUrl, form
     const { fhirUrl } = useContext(EnvironmentContext);
     const { setUserDetails } = useContext(UserContext);
 
+    const { progress, start, onProgress, finish } = useStreamProgress();
+
     const baseApi = React.useMemo(
         () => new BaseApi({ fhirUrl, setUserDetails }),
         [fhirUrl, setUserDetails]
@@ -116,8 +119,9 @@ const SpreadsheetViewer: React.FC<SpreadsheetViewerProps> = ({ relativeUrl, form
             try {
                 setIsLoading(true);
                 setErrorMessage(null);
+                start();
 
-                const response = await baseApi.downloadFile(downloadUri.toString());
+                const response = await baseApi.downloadFile(downloadUri.toString(), { onProgress });
 
                 if (response.status !== 200) {
                     throw new Error(`HTTP ${response.status}: Failed to fetch spreadsheet`);
@@ -200,14 +204,16 @@ const SpreadsheetViewer: React.FC<SpreadsheetViewerProps> = ({ relativeUrl, form
 
                 setSheets(parsedSheets);
                 setIsLoading(false);
+                finish();
             } catch (error) {
                 setErrorMessage(`Failed to load spreadsheet: ${(error as Error).message}`);
                 setIsLoading(false);
+                finish();
             }
         };
 
         fetchSpreadsheetData().then((r) => r);
-    }, [relativeUrl, hideEmptyColumns, downloadUri, format, baseApi]);
+    }, [relativeUrl, hideEmptyColumns, downloadUri, format, baseApi, start, onProgress, finish]);
 
     const defaultColDef = useMemo(
         () => ({
@@ -263,7 +269,7 @@ const SpreadsheetViewer: React.FC<SpreadsheetViewerProps> = ({ relativeUrl, form
             <Box
                 sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', height: '100%' }}
             >
-                <CircularProgress />
+                <StreamProgressIndicator progress={progress} />
                 <Typography variant="body2" sx={{ mt: 2 }}>
                     Loading spreadsheet...
                 </Typography>

--- a/src/components/StreamProgressIndicator.tsx
+++ b/src/components/StreamProgressIndicator.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box, LinearProgress, Typography } from '@mui/material';
+import { StreamProgressState } from '../hooks/useStreamProgress';
+
+function formatBytes(bytes: number): string {
+    if (bytes < 1024) {
+        return `${bytes} B`;
+    }
+    if (bytes < 1024 * 1024) {
+        return `${(bytes / 1024).toFixed(1)} KB`;
+    }
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+interface StreamProgressIndicatorProps {
+    progress: StreamProgressState;
+}
+
+const StreamProgressIndicator: React.FC<StreamProgressIndicatorProps> = ({ progress }) => {
+    if (!progress.isStreaming) {
+        return null;
+    }
+    const percent = progress.totalBytes
+        ? Math.min(100, Math.round((progress.bytesReceived / progress.totalBytes) * 100))
+        : undefined;
+    return (
+        <Box sx={{ width: '100%', my: 2 }}>
+            <LinearProgress variant={percent !== undefined ? 'determinate' : 'indeterminate'} value={percent} />
+            <Typography variant="caption" sx={{ mt: 0.5, display: 'block' }}>
+                {percent !== undefined
+                    ? `Loading… ${formatBytes(progress.bytesReceived)} of ${formatBytes(progress.totalBytes as number)} (${percent}%)`
+                    : `Loading… ${formatBytes(progress.bytesReceived)} received`}
+            </Typography>
+        </Box>
+    );
+};
+
+export default StreamProgressIndicator;

--- a/src/hooks/useStreamProgress.ts
+++ b/src/hooks/useStreamProgress.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react';
+
+export interface StreamProgressState {
+    bytesReceived: number;
+    totalBytes: number | undefined;
+    isStreaming: boolean;
+}
+
+const INITIAL_STATE: StreamProgressState = {
+    bytesReceived: 0,
+    totalBytes: undefined,
+    isStreaming: false,
+};
+
+export function useStreamProgress() {
+    const [progress, setProgress] = useState<StreamProgressState>(INITIAL_STATE);
+
+    const start = useCallback(() => {
+        setProgress({ bytesReceived: 0, totalBytes: undefined, isStreaming: true });
+    }, []);
+
+    const onProgress = useCallback((bytesReceived: number, totalBytes: number | undefined) => {
+        setProgress((prev) => ({ ...prev, bytesReceived, totalBytes, isStreaming: true }));
+    }, []);
+
+    const finish = useCallback(() => {
+        setProgress((prev) => ({ ...prev, isStreaming: false }));
+    }, []);
+
+    return { progress, start, onProgress, finish };
+}

--- a/src/pages/CompositionSummaryPage.tsx
+++ b/src/pages/CompositionSummaryPage.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
-import { Alert, Box, CircularProgress } from '@mui/material';
+import { Alert, Box } from '@mui/material';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import CompositionSummary from '../components/CompositionSummary';
@@ -11,6 +11,8 @@ import LastRequestContext from '../context/LastRequestContext';
 import BaseApi from '../api/baseApi';
 import { TComposition } from '../types/resources/Composition';
 import { appendFormatJson } from '../utils/url.utils';
+import { useStreamProgress } from '../hooks/useStreamProgress';
+import StreamProgressIndicator from '../components/StreamProgressIndicator';
 
 const CompositionSummaryPage: React.FC = () => {
     const { resourceType, id, operation } = useParams<{
@@ -23,6 +25,9 @@ const CompositionSummaryPage: React.FC = () => {
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [resource, setResource] = useState<TComposition | null>(null);
     const [rawResponse, setRawResponse] = useState<Object | null>(null);
+    const [isIncomplete, setIsIncomplete] = useState<boolean>(false);
+
+    const { progress, start, onProgress, finish } = useStreamProgress();
 
     const { fhirUrl } = useContext(EnvironmentContext);
     const { setUserDetails } = useContext(UserContext);
@@ -60,10 +65,13 @@ const CompositionSummaryPage: React.FC = () => {
         const fetchResource = async () => {
             setIsLoading(true);
             setErrorMessage(null);
+            setIsIncomplete(false);
+            start();
             try {
-                const response = await baseApi.getData({ urlString: relativeUrl });
+                const response = await baseApi.getData({ urlString: relativeUrl }, { onProgress });
                 const json = response.json;
                 setRawResponse(json);
+                setIsIncomplete(response.incomplete);
                 if (json?.resourceType === 'Composition') {
                     setResource(json);
                 } else {
@@ -74,6 +82,7 @@ const CompositionSummaryPage: React.FC = () => {
                 setErrorMessage('Failed to load the Composition resource');
             } finally {
                 setIsLoading(false);
+                finish();
             }
         };
 
@@ -99,9 +108,14 @@ const CompositionSummaryPage: React.FC = () => {
             <Header />
             <Box sx={{ flex: 1, width: '100%', padding: '20px', boxSizing: 'border-box' }}>
                 {isLoading && (
-                    <Box sx={{ display: 'flex', justifyContent: 'center', my: 4 }}>
-                        <CircularProgress />
+                    <Box sx={{ my: 4 }}>
+                        <StreamProgressIndicator progress={progress} />
                     </Box>
+                )}
+                {!isLoading && isIncomplete && (
+                    <Alert severity="warning" sx={{ mb: 2 }}>
+                        Connection interrupted — showing partial results.
+                    </Alert>
                 )}
                 {!isLoading && errorMessage && (
                     <>

--- a/src/pages/CompositionSummaryPage.tsx
+++ b/src/pages/CompositionSummaryPage.tsx
@@ -91,7 +91,7 @@ const CompositionSummaryPage: React.FC = () => {
         return () => {
             document.title = 'FHIR Viewer';
         };
-    }, [relativeUrl, baseApi, id, resourceType]);
+    }, [relativeUrl, baseApi, id, resourceType, start, onProgress, finish]);
 
     return (
         <Box

--- a/src/pages/CompositionSummaryPage.tsx
+++ b/src/pages/CompositionSummaryPage.tsx
@@ -74,6 +74,8 @@ const CompositionSummaryPage: React.FC = () => {
                 setIsIncomplete(response.incomplete);
                 if (json?.resourceType === 'Composition') {
                     setResource(json);
+                } else if (response.incomplete && !json) {
+                    setErrorMessage('Connection interrupted before any data was received — please retry.');
                 } else {
                     setErrorMessage('The requested resource is not a Composition');
                 }

--- a/src/pages/IndexPage.tsx
+++ b/src/pages/IndexPage.tsx
@@ -89,7 +89,12 @@ const IndexPage = ({ search }: { search?: boolean }) => {
                     </Box>
                 )}
                 {/* if we have a single resource*/}
-                {resources && resources.length === 1 && resources[0].text?.div && (
+                {/* Gated on !loading: during incremental streaming, `resources` can transiently
+                    have length 1 (the first entry to finish parsing) before the rest of the
+                    Bundle arrives — without this guard, a resource that happens to carry a
+                    narrative would flash this "Answer" banner as if it were the sole, definitive
+                    result, then have it disappear once the next entry streams in. */}
+                {!loading && resources && resources.length === 1 && resources[0].text?.div && (
                     <Alert severity="success">
                         <AlertTitle>Answer</AlertTitle>
                         <Box
@@ -100,7 +105,7 @@ const IndexPage = ({ search }: { search?: boolean }) => {
                     </Alert>
                 )}
                 {/*if we have a list of resources*/}
-                {resources && resources.length === 1 && resources[0].resource?.text?.div && (
+                {!loading && resources && resources.length === 1 && resources[0].resource?.text?.div && (
                     <Alert severity="success">
                         <AlertTitle>Answer</AlertTitle>
                         <Box
@@ -156,6 +161,14 @@ const IndexPage = ({ search }: { search?: boolean }) => {
         if (id) {
             setResourceCardExpanded(true);
         }
+        // Guards every state write below against a request this effect has abandoned — e.g. the
+        // user navigates from one resourceType/query to another before a large, slow search
+        // finishes streaming. Without this, the abandoned request's onChunk callback keeps
+        // calling setResources with stale data (from the OLD resourceType) for as long as its
+        // download continues, and its terminal setLoading(false) can clear the loading spinner
+        // for the NEW, still-in-flight request. The cleanup function below flips this once a
+        // newer effect run supersedes this one.
+        let cancelled = false;
         const callApi = async () => {
             document.title = 'FHIR Server';
             if (operation === '$merge' && !shouldBeJsonFormat) {
@@ -222,14 +235,24 @@ const IndexPage = ({ search }: { search?: boolean }) => {
                                           // Render whatever the parser found in this chunk. Batching per
                                           // chunk (rather than per entry) keeps re-renders proportional to
                                           // the number of network chunks received, not the number of
-                                          // resources in the Bundle.
-                                          setResources([...incrementalResults]);
+                                          // resources in the Bundle. Skipped once this effect has been
+                                          // superseded, so an abandoned request can't overwrite a newer
+                                          // search's results while its stream keeps delivering chunks.
+                                          if (!cancelled) {
+                                              setResources([...incrementalResults]);
+                                          }
                                       }
                                   }
                                 : undefined,
                         }
                     );
                     streamParser?.finish();
+
+                    if (cancelled) {
+                        // A newer effect run has already taken over — don't let this abandoned
+                        // request's terminal, authoritative result overwrite it.
+                        return;
+                    }
 
                     // set indexStart
                     const queryParams = new URLSearchParams(location.search || '');
@@ -274,10 +297,15 @@ const IndexPage = ({ search }: { search?: boolean }) => {
             } catch (error) {
                 console.error(error);
             } finally {
-                setLoading(false);
+                if (!cancelled) {
+                    setLoading(false);
+                }
             }
         };
         callApi().catch(console.error);
+        return () => {
+            cancelled = true;
+        };
     }, [
         id,
         queryString,

--- a/src/pages/IndexPage.tsx
+++ b/src/pages/IndexPage.tsx
@@ -55,18 +55,19 @@ const IndexPage = ({ search }: { search?: boolean }) => {
         (new URLSearchParams(queryString || '').get('_format') || '').toLowerCase() === 'json';
 
     function getBox() {
-        if (loading) {
+        if (loading && !resources?.length) {
             return <LinearProgress />;
         }
-        if (status === 401) {
+        if (!loading && status === 401) {
             return <Box>Login Expired</Box>;
         }
-        if (resources && resources.length === 0) {
+        if (!loading && resources && resources.length === 0) {
             return <Box>No Results Found</Box>;
         }
         // If narrative is returned then show it at top level
         return (
             <>
+                {loading && <LinearProgress />}
                 {resources?.length > 1 && (
                     <Box sx={{ display: 'flex', justifyContent: 'end' }}>
                         <Button
@@ -184,13 +185,14 @@ const IndexPage = ({ search }: { search?: boolean }) => {
                         ? undefined
                         : createBundleEntryParser(
                               (resource) => {
-                                  incrementalResults = [...incrementalResults, resource];
-                                  // Render each resource as it parses. The end-of-stream full JSON.parse
-                                  // result (below) still overwrites this once the response completes, so
-                                  // a parser miss never leaves the page silently short of data — it just
-                                  // skips the "populate live" effect for whatever wasn't caught
-                                  // incrementally.
-                                  setResources(incrementalResults);
+                                  // Accumulate without copying per entry — the array is copied once per
+                                  // network chunk (below), not once per resource, so a large Bundle
+                                  // doesn't trigger one React re-render per entry. The end-of-stream full
+                                  // JSON.parse result (below) still overwrites this once the response
+                                  // completes, so a parser miss never leaves the page silently short of
+                                  // data — it just skips the "populate live" effect for whatever wasn't
+                                  // caught incrementally.
+                                  incrementalResults.push(resource);
                               },
                               (err) => {
                                   console.error(
@@ -217,6 +219,11 @@ const IndexPage = ({ search }: { search?: boolean }) => {
                                 ? (chunk) => {
                                       if (!parserFailed) {
                                           streamParser.write(chunk);
+                                          // Render whatever the parser found in this chunk. Batching per
+                                          // chunk (rather than per entry) keeps re-renders proportional to
+                                          // the number of network chunks received, not the number of
+                                          // resources in the Bundle.
+                                          setResources([...incrementalResults]);
                                       }
                                   }
                                 : undefined,
@@ -243,6 +250,14 @@ const IndexPage = ({ search }: { search?: boolean }) => {
                     } else if (json && json.entry) {
                         setResources(json.entry);
                         setBundle(json);
+                        if (resourceType) {
+                            document.title = resourceType;
+                        }
+                    } else if (incomplete && incrementalResults.length > 0) {
+                        // Connection dropped before the full Bundle could be parsed, but the incremental
+                        // parser already captured some resources from what did arrive — keep those instead
+                        // of wiping the list to empty.
+                        setResources(incrementalResults);
                         if (resourceType) {
                             document.title = resourceType;
                         }

--- a/src/pages/IndexPage.tsx
+++ b/src/pages/IndexPage.tsx
@@ -20,6 +20,7 @@ import GridOnIcon from '@mui/icons-material/GridOn'; // New icon for spreadsheet
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { getLocalData } from '../utils/localData.utils';
 import APIConsolePage from './APIConsolePage';
+import { createBundleEntryParser } from '../utils/incrementalBundleParser';
 
 /**
  * IndexPage/home/ubuntu/Documents/code/EFS/fhir-server/src/pages/SearchPage.jsx
@@ -176,12 +177,52 @@ const IndexPage = ({ search }: { search?: boolean }) => {
                         setUserDetails,
                         onRequest: recordRequest,
                     });
-                    const { json, status: statusCode } = await fhirApi.getBundleAsync({
-                        resourceType,
-                        id,
-                        queryString,
-                        operation: vid ? `_history/${vid}` : operation,
-                    });
+
+                    let incrementalResults: any[] = [];
+                    let parserFailed = false;
+                    const streamParser = shouldBeJsonFormat
+                        ? undefined
+                        : createBundleEntryParser(
+                              (resource) => {
+                                  incrementalResults = [...incrementalResults, resource];
+                                  // Render each resource as it parses. The end-of-stream full JSON.parse
+                                  // result (below) still overwrites this once the response completes, so
+                                  // a parser miss never leaves the page silently short of data — it just
+                                  // skips the "populate live" effect for whatever wasn't caught
+                                  // incrementally.
+                                  setResources(incrementalResults);
+                              },
+                              (err) => {
+                                  console.error(
+                                      'Incremental bundle parsing failed, falling back to full parse:',
+                                      err
+                                  );
+                                  parserFailed = true;
+                              }
+                          );
+
+                    const {
+                        json,
+                        status: statusCode,
+                        incomplete,
+                    } = await fhirApi.getBundleAsync(
+                        {
+                            resourceType,
+                            id,
+                            queryString,
+                            operation: vid ? `_history/${vid}` : operation,
+                        },
+                        {
+                            onChunk: streamParser
+                                ? (chunk) => {
+                                      if (!parserFailed) {
+                                          streamParser.write(chunk);
+                                      }
+                                  }
+                                : undefined,
+                        }
+                    );
+                    streamParser?.finish();
 
                     // set indexStart
                     const queryParams = new URLSearchParams(location.search || '');
@@ -192,6 +233,11 @@ const IndexPage = ({ search }: { search?: boolean }) => {
 
                     // noinspection JSCheckFunctionSignatures
                     setStatus(statusCode);
+                    if (incomplete) {
+                        console.warn(
+                            'Search response was interrupted mid-stream; results may be incomplete until retried.'
+                        );
+                    }
                     if (shouldBeJsonFormat) {
                         setResources(json);
                     } else if (json && json.entry) {

--- a/src/utils/incrementalBundleParser.ts
+++ b/src/utils/incrementalBundleParser.ts
@@ -1,0 +1,35 @@
+import { JSONParser } from '@streamparser/json';
+
+/**
+ * Wraps @streamparser/json to emit each Bundle.entry[].resource as it completes, instead of
+ * waiting for the whole Bundle JSON object to finish downloading.
+ *
+ * The underlying tokenizer is stream-fatal: a single malformed token anywhere aborts the whole
+ * parse (it's one continuous tokenizer over the byte stream, not a per-entry recovery
+ * mechanism), so onError should be treated as "stop calling write(), fall back to the
+ * caller's own full JSON.parse of the complete response" rather than "skip one bad entry."
+ *
+ * With no `separator` option, the parser auto-ends after the single top-level Bundle object
+ * completes — calling finish() after that would throw, so finish() checks isEnded first.
+ */
+export function createBundleEntryParser(
+    onEntry: (resource: any) => void,
+    onError: (err: Error) => void
+): { write: (chunk: Uint8Array) => void; finish: () => void } {
+    const parser = new JSONParser({ paths: ['$.entry.*.resource'], keepStack: false });
+    parser.onValue = ({ value }) => onEntry(value);
+    parser.onError = onError;
+
+    return {
+        write: (chunk: Uint8Array) => {
+            if (!parser.isEnded) {
+                parser.write(chunk);
+            }
+        },
+        finish: () => {
+            if (!parser.isEnded) {
+                parser.end();
+            }
+        },
+    };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,6 +1749,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@streamparser/json@npm:^0.0.23":
+  version: 0.0.23
+  resolution: "@streamparser/json@npm:0.0.23"
+  checksum: 10c0/88d9b61559ccc52cdea71a0cdafa0a3872e4924357429dab5122f357ee47a5878cd330ff26f66968d0772dcae3c38cb5c6d4da11d51ad51489c9f0a70306fbe7
+  languageName: node
+  linkType: hard
+
 "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0":
   version: 8.0.0
   resolution: "@svgr/babel-plugin-add-jsx-attribute@npm:8.0.0"
@@ -3224,6 +3231,7 @@ __metadata:
     "@mui/material": "npm:^9.0.1"
     "@mui/x-date-pickers": "npm:^9.3.0"
     "@sentry/react": "npm:10.53.1"
+    "@streamparser/json": "npm:^0.0.23"
     "@types/file-saver": "npm:^2.0.7"
     "@types/node": "npm:^25.9.1"
     "@types/react": "npm:^19.2.15"


### PR DESCRIPTION
## Summary
- Generalizes the API Console's existing `fetch()`+`ReadableStream` pattern into a shared `BaseApi.streamRequest()`, so `getData()`/`request()`/`downloadFile()`/`FhirApi.sendRequest()` all consume the FHIR server progressively instead of buffering the whole response — axios is removed from `BaseApi` entirely.
- Adds a shared `useStreamProgress`/`StreamProgressIndicator` and wires it into `CompositionSummaryPage`, `IPSViewer`, `SpreadsheetViewer`, and `FileDownload` so large downloads show live progress instead of a static spinner, and resist idle-timeouts since bytes keep flowing.
- Adds `@streamparser/json` and an incremental Bundle-entry parser wired into `IndexPage` (the main search/browse page), so `ResourceCard`s render as the search Bundle streams in rather than all at once at the end.

Design spec: `docs/superpowers/specs/2026-08-06-fhir-streaming-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-06-fhir-streaming-implementation.md`

Built and reviewed task-by-task (14 tasks across 3 phases), plus a final whole-branch review that caught and fixed 1 critical + 6 important cross-task issues before merge — most notably that the incremental-rendering gate in `IndexPage.tsx` initially suppressed its own feature, and that `downloadFile()` was double-buffering large files in memory.

## Test plan
This repo has no automated test framework yet (Vitest is being added in a separate PR), so verification was `yarn tsc --noEmit` + `yarn lint` (both clean) plus manual/static review at every step. **No task in this branch was exercised against a live FHIR server** (none was reachable in the sandbox this was built in) — please do a live QA pass before merging:

- [ ] Search page on throttled network (`_count=50`+) — cards appear progressively, not all at once
- [ ] Same load — progress caption reads sensibly (not >100%) including against a gzip-compressed response
- [ ] `IPSViewer` / `CompositionSummaryPage` on a large `$summary` — progress bar shows, content renders correctly
- [ ] Spreadsheet view + file download — file saves with the correct filename and opens correctly
- [ ] API Console — streaming body accumulates live, status/headers populate early, mid-request cancel works, cross-origin path is rejected
- [ ] One AdminApi write path (e.g. `personPatientLink` create/remove)
- [ ] A large bulk `$everything` export, to confirm the download memory fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)